### PR TITLE
Use an anonymous module declaration for AMD.

### DIFF
--- a/src/epilogue.js
+++ b/src/epilogue.js
@@ -2,7 +2,7 @@ if( typeof module !== "undefined" && module.exports ) {
     module.exports = Promise;
 }
 else if( typeof define === "function" && define.amd ) {
-    define( "Promise", [], function(){return Promise;});
+    define(function(){return Promise;});
 }
 else {
     global.Promise = Promise;


### PR DESCRIPTION
This allows loading via AMD using require('bluebird'), to match the npm module name.  This would be useful for me as I want to be able to reuse the code between the browser and node, but I currently have to use require('Promise') in the browser (due to the named module) and require('bluebird') in node.
