### PR TITLE
Fix long stack traces docs issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ If you want to also enable long stack traces, call:
 Promise.longStackTraces();
 ```
 
+right after the library is loaded.
+
 In node.js use the environment flag `BLUEBIRD_DEBUG`:
 
 ```
@@ -112,7 +114,7 @@ BLUEBIRD_DEBUG=1 node server.js
 
 to enable long stack traces in all instances of bluebird.
 
-right after the library is loaded. Long stack traces cannot be disabled after being enabled, and cannot be enabled after promises have alread been created. Long stack traces imply a substantial performance penalty, even after using every trick to optimize them.
+Long stack traces cannot be disabled after being enabled, and cannot be enabled after promises have alread been created. Long stack traces imply a substantial performance penalty, even after using every trick to optimize them.
 
 Long stack traces are enabled by default in the debug build.
 


### PR DESCRIPTION
The paragraph ordering was incorrect in the BLUEBIRD_DEBUG patch.
