### PR TITLE
Added support for predicate error filters.

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@
     - [`new Promise(Function<Function resolve, Function reject> resolver)`](#new-promisefunctionfunction-resolve-function-reject-resolver---promise)
     - [`.then([Function fulfilledHandler] [, Function rejectedHandler ] [, Function progressHandler ])`](#thenfunction-fulfilledhandler--function-rejectedhandler---function-progresshandler----promise)
     - [`.catch(Function handler)`](#catchfunction-handler---promise)
-    - [`.catch([Function ErrorClass...], Function handler)`](#catchfunction-errorclass-function-handler---promise)
+    - [`.catch([Function ErrorClass|Function predicate...], Function handler)`](#catchfunction-errorclass-function-handler---promise)
     - [`.finally(Function handler)`](#finallyfunction-handler---promise)
     - [`.bind(dynamic thisArg)`](#binddynamic-thisarg---promise)
     - [`.done([Function fulfilledHandler] [, Function rejectedHandler ] [, Function progressHandler ])`](#donefunction-fulfilledhandler--function-rejectedhandler---function-progresshandler----promise)
@@ -143,9 +143,18 @@ This is a catch-all exception handler, shortcut for calling `.then(null, handler
 
 <hr>
 
-#####`.catch([Function ErrorClass...], Function handler)` -> `Promise`
+#####`.catch([Function ErrorClass|Function predicate...], Function handler)` -> `Promise`
 
 This extends `.catch` to work more like catch-clauses in languages like Java or C#. Instead of manually checking `instanceof` or `.name === "SomeError"`, you may specify a number of error constructors which are eligible for this catch handler. The catch handler that is first met that has eligible constructors specified, is the one that will be called.
+
+This method also supports predicate-based filters. If you pass a 
+predicate function instead of an error constructor, the predicate will receive
+the error as an argument. The return result of the predicate will be used 
+determine whether the error handler should be called. 
+
+Predicates should allow for very fine grained control over caught errors:
+pattern matching, error-type sets with set operations and many other techniques
+can be implemented on top of them.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,16 @@ Since a `catch` handler typed to `Promise.RejectionError` is expected to be used
 });
 ```
 
+Finally, Bluebird also supports predicate-based filters. If you pass a 
+predicate function instead of an error type, the predicate will receive
+the error as an argument. The return result will be used determine whether 
+the error handler should be called. 
+
+Predicates should allow for very fine grained control over caught errors:
+pattern matching, error typesets with set operations and many other techniques
+can be implemented on top of them.
+
+
 See [API documentation for `.error()`](https://github.com/petkaantonov/bluebird/blob/master/API.md#error-rejectedhandler----promise)
 
 <hr>

--- a/js/debug/catch_filter.js
+++ b/js/debug/catch_filter.js
@@ -25,11 +25,28 @@ var util = require( "./util.js");
 var tryCatch1 = util.tryCatch1;
 var errorObj = util.errorObj;
 
-function CatchFilter( instances, callback, boundTo ) {
+function CatchFilter( instances, callback, promise ) {
     this._instances = instances;
     this._callback = callback;
-    this._boundTo = boundTo;
+    this._promise = promise;
 }
+
+
+function safePredicate(predicate, e) {
+    var safeObject = {};
+    var retfilter = tryCatch1(predicate, safeObject, e);
+    if (retfilter === errorObj)
+        return retfilter;
+    var safeKeys = Object.keys(safeObject);
+    if (safeKeys.length) {
+        errorObj.e = new TypeError(
+            "Catch filter must inherit from Error "
+          + "or be a simple predicate function");
+        return errorObj;
+    }
+    return retfilter;
+}
+
 CatchFilter.prototype.doFilter = function CatchFilter$doFilter( e ) {
     if( e === null || typeof e !== "object" ) {
         throw e;
@@ -37,12 +54,27 @@ CatchFilter.prototype.doFilter = function CatchFilter$doFilter( e ) {
     var cb = this._callback;
     for( var i = 0, len = this._instances.length; i < len; ++i ) {
         var item = this._instances[i];
-        if( e instanceof item ) {
-            var ret = tryCatch1( cb, this._boundTo, e );
+        var itemIsErrorType = item === Error ||
+            (item != null && item.prototype instanceof Error);
+
+        if( e instanceof item && itemIsErrorType ) {
+            var ret = tryCatch1( cb, this._promise._boundTo, e );
             if( ret === errorObj ) {
                 throw ret.e;
             }
             return ret;
+        } else if( typeof item === "function" && !itemIsErrorType ) {
+            var shouldHandle = safePredicate(item, e);
+            if (shouldHandle === errorObj) {
+                this._promise._attachExtraTrace(errorObj.e);
+                e = errorObj.e;
+            } else if (shouldHandle) {
+                var ret = tryCatch1( cb, this._promise._boundTo, e );
+                if( ret === errorObj ) {
+                    throw ret.e;
+                }
+                return ret;
+            }
         }
     }
     ensureNotHandled( e );

--- a/js/debug/promise.js
+++ b/js/debug/promise.js
@@ -97,15 +97,14 @@ function Promise$catch( fn ) {
             j = 0, i;
         for( i = 0; i < len - 1; ++i ) {
             var item = arguments[i];
-            if( typeof item === "function" &&
-                ( item.prototype instanceof Error ||
-                item === Error ) ) {
+            if( typeof item === "function" ) {
                 catchInstances[j++] = item;
             }
             else {
                 var catchFilterTypeError =
                     new TypeError(
-                        "A catch filter must be an error constructor");
+                        "A catch filter must be an error constructor "
+                        + "or a filter function");
 
                 this._attachExtraTrace( catchFilterTypeError );
                 async.invoke( this._reject, this, catchFilterTypeError );
@@ -114,7 +113,7 @@ function Promise$catch( fn ) {
         }
         catchInstances.length = j;
         fn = arguments[i];
-        var catchFilter = new CatchFilter( catchInstances, fn, this._boundTo );
+        var catchFilter = new CatchFilter( catchInstances, fn, this );
         return this._then( void 0, catchFilter.doFilter, void 0,
             catchFilter, void 0, this.caught );
     }

--- a/js/main/catch_filter.js
+++ b/js/main/catch_filter.js
@@ -25,11 +25,28 @@ var util = require( "./util.js");
 var tryCatch1 = util.tryCatch1;
 var errorObj = util.errorObj;
 
-function CatchFilter( instances, callback, boundTo ) {
+function CatchFilter( instances, callback, promise ) {
     this._instances = instances;
     this._callback = callback;
-    this._boundTo = boundTo;
+    this._promise = promise;
 }
+
+
+function safePredicate(predicate, e) {
+    var safeObject = {};
+    var retfilter = tryCatch1(predicate, safeObject, e);
+    if (retfilter === errorObj)
+        return retfilter;
+    var safeKeys = Object.keys(safeObject);
+    if (safeKeys.length) {
+        errorObj.e = new TypeError(
+            "Catch filter must inherit from Error "
+          + "or be a simple predicate function");
+        return errorObj;
+    }
+    return retfilter;
+}
+
 CatchFilter.prototype.doFilter = function CatchFilter$doFilter( e ) {
     if( e === null || typeof e !== "object" ) {
         throw e;
@@ -37,12 +54,27 @@ CatchFilter.prototype.doFilter = function CatchFilter$doFilter( e ) {
     var cb = this._callback;
     for( var i = 0, len = this._instances.length; i < len; ++i ) {
         var item = this._instances[i];
-        if( e instanceof item ) {
-            var ret = tryCatch1( cb, this._boundTo, e );
+        var itemIsErrorType = item === Error ||
+            (item != null && item.prototype instanceof Error);
+
+        if( e instanceof item && itemIsErrorType ) {
+            var ret = tryCatch1( cb, this._promise._boundTo, e );
             if( ret === errorObj ) {
                 throw ret.e;
             }
             return ret;
+        } else if( typeof item === "function" && !itemIsErrorType ) {
+            var shouldHandle = safePredicate(item, e);
+            if (shouldHandle === errorObj) {
+                this._promise._attachExtraTrace(errorObj.e);
+                e = errorObj.e;
+            } else if (shouldHandle) {
+                var ret = tryCatch1( cb, this._promise._boundTo, e );
+                if( ret === errorObj ) {
+                    throw ret.e;
+                }
+                return ret;
+            }
         }
     }
     ensureNotHandled( e );

--- a/js/main/promise.js
+++ b/js/main/promise.js
@@ -97,15 +97,14 @@ function Promise$catch( fn ) {
             j = 0, i;
         for( i = 0; i < len - 1; ++i ) {
             var item = arguments[i];
-            if( typeof item === "function" &&
-                ( item.prototype instanceof Error ||
-                item === Error ) ) {
+            if( typeof item === "function" ) {
                 catchInstances[j++] = item;
             }
             else {
                 var catchFilterTypeError =
                     new TypeError(
-                        "A catch filter must be an error constructor");
+                        "A catch filter must be an error constructor "
+                        + "or a filter function");
 
                 this._attachExtraTrace( catchFilterTypeError );
                 async.invoke( this._reject, this, catchFilterTypeError );
@@ -114,7 +113,7 @@ function Promise$catch( fn ) {
         }
         catchInstances.length = j;
         fn = arguments[i];
-        var catchFilter = new CatchFilter( catchInstances, fn, this._boundTo );
+        var catchFilter = new CatchFilter( catchInstances, fn, this );
         return this._then( void 0, catchFilter.doFilter, void 0,
             catchFilter, void 0, this.caught );
     }

--- a/js/zalgo/catch_filter.js
+++ b/js/zalgo/catch_filter.js
@@ -25,11 +25,28 @@ var util = require( "./util.js");
 var tryCatch1 = util.tryCatch1;
 var errorObj = util.errorObj;
 
-function CatchFilter( instances, callback, boundTo ) {
+function CatchFilter( instances, callback, promise ) {
     this._instances = instances;
     this._callback = callback;
-    this._boundTo = boundTo;
+    this._promise = promise;
 }
+
+
+function safePredicate(predicate, e) {
+    var safeObject = {};
+    var retfilter = tryCatch1(predicate, safeObject, e);
+    if (retfilter === errorObj)
+        return retfilter;
+    var safeKeys = Object.keys(safeObject);
+    if (safeKeys.length) {
+        errorObj.e = new TypeError(
+            "Catch filter must inherit from Error "
+          + "or be a simple predicate function");
+        return errorObj;
+    }
+    return retfilter;
+}
+
 CatchFilter.prototype.doFilter = function CatchFilter$doFilter( e ) {
     if( e === null || typeof e !== "object" ) {
         throw e;
@@ -37,12 +54,27 @@ CatchFilter.prototype.doFilter = function CatchFilter$doFilter( e ) {
     var cb = this._callback;
     for( var i = 0, len = this._instances.length; i < len; ++i ) {
         var item = this._instances[i];
-        if( e instanceof item ) {
-            var ret = tryCatch1( cb, this._boundTo, e );
+        var itemIsErrorType = item === Error ||
+            (item != null && item.prototype instanceof Error);
+
+        if( e instanceof item && itemIsErrorType ) {
+            var ret = tryCatch1( cb, this._promise._boundTo, e );
             if( ret === errorObj ) {
                 throw ret.e;
             }
             return ret;
+        } else if( typeof item === "function" && !itemIsErrorType ) {
+            var shouldHandle = safePredicate(item, e);
+            if (shouldHandle === errorObj) {
+                this._promise._attachExtraTrace(errorObj.e);
+                e = errorObj.e;
+            } else if (shouldHandle) {
+                var ret = tryCatch1( cb, this._promise._boundTo, e );
+                if( ret === errorObj ) {
+                    throw ret.e;
+                }
+                return ret;
+            }
         }
     }
     ensureNotHandled( e );

--- a/js/zalgo/promise.js
+++ b/js/zalgo/promise.js
@@ -97,15 +97,14 @@ function Promise$catch( fn ) {
             j = 0, i;
         for( i = 0; i < len - 1; ++i ) {
             var item = arguments[i];
-            if( typeof item === "function" &&
-                ( item.prototype instanceof Error ||
-                item === Error ) ) {
+            if( typeof item === "function" ) {
                 catchInstances[j++] = item;
             }
             else {
                 var catchFilterTypeError =
                     new TypeError(
-                        "A catch filter must be an error constructor");
+                        "A catch filter must be an error constructor "
+                        + "or a filter function");
 
                 this._attachExtraTrace( catchFilterTypeError );
                 this._reject(catchFilterTypeError);
@@ -114,7 +113,7 @@ function Promise$catch( fn ) {
         }
         catchInstances.length = j;
         fn = arguments[i];
-        var catchFilter = new CatchFilter( catchInstances, fn, this._boundTo );
+        var catchFilter = new CatchFilter( catchInstances, fn, this );
         return this._then( void 0, catchFilter.doFilter, void 0,
             catchFilter, void 0, this.caught );
     }

--- a/src/catch_filter.js
+++ b/src/catch_filter.js
@@ -4,11 +4,28 @@ var util = require( "./util.js");
 var tryCatch1 = util.tryCatch1;
 var errorObj = util.errorObj;
 
-function CatchFilter( instances, callback, boundTo ) {
+function CatchFilter( instances, callback, promise ) {
     this._instances = instances;
     this._callback = callback;
-    this._boundTo = boundTo;
+    this._promise = promise;
 }
+
+
+function safePredicate(predicate, e) {
+    var safeObject = {};
+    var retfilter = tryCatch1(predicate, safeObject, e);
+    if (retfilter === errorObj)
+        return retfilter;
+    var safeKeys = Object.keys(safeObject);
+    if (safeKeys.length) {
+        errorObj.e = new TypeError(
+            "Catch filter must inherit from Error "
+          + "or be a simple predicate function");
+        return errorObj;
+    }
+    return retfilter;
+}
+
 CatchFilter.prototype.doFilter = function CatchFilter$doFilter( e ) {
     if( e === null || typeof e !== "object" ) {
         throw e;
@@ -16,12 +33,29 @@ CatchFilter.prototype.doFilter = function CatchFilter$doFilter( e ) {
     var cb = this._callback;
     for( var i = 0, len = this._instances.length; i < len; ++i ) {
         var item = this._instances[i];
-        if( e instanceof item ) {
-            var ret = tryCatch1( cb, this._boundTo, e );
+        var itemIsErrorType = item === Error ||
+            (item != null && item.prototype instanceof Error);
+
+        if( e instanceof item && itemIsErrorType ) {
+            var ret = tryCatch1( cb, this._promise._boundTo, e );
             if( ret === errorObj ) {
                 throw ret.e;
             }
             return ret;
+        } else if( typeof item === "function" && !itemIsErrorType ) {
+            var shouldHandle = safePredicate(item, e);
+            if (shouldHandle === errorObj) {
+                this._promise._attachExtraTrace(errorObj.e);
+                // TODO: Should we switch to this error? Filter errors
+                // are programmer errors and take priority, right?
+                e = errorObj.e;
+            } else if (shouldHandle) {
+                var ret = tryCatch1( cb, this._promise._boundTo, e );
+                if( ret === errorObj ) {
+                    throw ret.e;
+                }
+                return ret;
+            }
         }
     }
     ensureNotHandled( e );

--- a/src/promise.js
+++ b/src/promise.js
@@ -93,15 +93,14 @@ function Promise$catch( fn ) {
             j = 0, i;
         for( i = 0; i < len - 1; ++i ) {
             var item = arguments[i];
-            if( typeof item === "function" &&
-                ( item.prototype instanceof Error ||
-                item === Error ) ) {
+            if( typeof item === "function" ) {
                 catchInstances[j++] = item;
             }
             else {
                 var catchFilterTypeError =
                     new TypeError(
-                        "A catch filter must be an error constructor");
+                        "A catch filter must be an error constructor "
+                        + "or a filter function");
 
                 this._attachExtraTrace( catchFilterTypeError );
                 async.invoke( this._reject, this, catchFilterTypeError );
@@ -110,7 +109,7 @@ function Promise$catch( fn ) {
         }
         catchInstances.length = j;
         fn = arguments[i];
-        var catchFilter = new CatchFilter( catchInstances, fn, this._boundTo );
+        var catchFilter = new CatchFilter( catchInstances, fn, this );
         return this._then( void 0, catchFilter.doFilter, void 0,
             catchFilter, void 0, this.caught );
     }


### PR DESCRIPTION
Bluebird now supports predicate error filters. The format is:

```
promise.catch(predicateFilter, function(e) { });
```

where predicateFilter is `function(error) => bool`

Predicate filters should allow for extremely fine-grained control of caught
errors: pattern matching, error-type sets with set operations and other
advanced techniques can be easily implemented on top of them.
