### PR TITLE
Add readme note about long stack trace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Browsers that [implement ECMA-262, edition 3](http://en.wikipedia.org/wiki/Ecmas
 
 **Note** that in ECMA-262, edition 3 (IE7, IE8 etc) it is not possible to use methods that have keyword names like `.catch` and `.finally`. The [API documentation](https://github.com/petkaantonov/bluebird/blob/master/API.md) always lists a compatible alternative name that you can use if you need to support these browsers. For example `.catch` is replaced with `.caught` and `.finally` with `.lastly`.
 
-Also, long stack trace support is only available in Chrome and Firefox.
+Also, [long stack trace](https://github.com/petkaantonov/bluebird/blob/master/API.md#promiselongstacktraces---void) support is only available in Chrome and Firefox.
 
 <sub>Previously bluebird required es5-shim.js and es5-sham.js to support Edition 3 - these are **no longer required** as of **0.10.4**.</sub>
 


### PR DESCRIPTION
In browser compatibility section, add note about the limited long stack trace support.
