### PR TITLE
Update global.js to correctly identify globals

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -15,6 +15,10 @@ module.exports = (function(){
         typeof document !== "undefined" &&
         typeof navigator !== "undefined" && navigator !== null &&
         typeof navigator.appName === "string") {
+            //Strict mode, Firefox extension
+            if(window.wrappedJSObject !== undefined){
+                return window.wrappedJSObject;
+            }
         return window;
     }
 })();


### PR DESCRIPTION
This commit fixes a problem with Firefox extensions. when we did `var Error = global.Error;` Error bacame undefined because `window` is not the global context in that scenario.

Steps to reproduce the issue solved:
- Create a new Firefox extension
- import Bluebird
- An error occurs in `inherits`, that error stems from Parent being undefined, which in that case is Error.

How this solves the issue:

In firefox extensions you can still access the global scope through window with `window.wrappedJSObject`. When we detect global - we now check for this.
