### PR TITLE
Moving INTERNAL to util.INTERNAL

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,21 +50,21 @@ module.exports = function( grunt ) {
 
 
     var optionalModuleDependencyMap = {
-        "timers.js": ['Promise', 'INTERNAL'],
+        "timers.js": ['Promise'],
         "any.js": ['Promise', 'Promise$_All', 'PromiseArray'],
-        "race.js": ['Promise', 'INTERNAL'],
+        "race.js": ['Promise'],
         "call_get.js": ['Promise'],
         "filter.js": ['Promise', 'Promise$_All', 'PromiseArray', 'apiRejection'],
-        "generators.js": ['Promise', 'apiRejection', 'INTERNAL'],
+        "generators.js": ['Promise', 'apiRejection'],
         "map.js": ['Promise', 'Promise$_All', 'PromiseArray', 'apiRejection'],
         "nodeify.js": ['Promise'],
-        "promisify.js": ['Promise', 'INTERNAL'],
+        "promisify.js": ['Promise'],
         "props.js": ['Promise', 'PromiseArray'],
         "reduce.js": ['Promise', 'Promise$_All', 'PromiseArray', 'apiRejection'],
         "settle.js": ['Promise', 'Promise$_All', 'PromiseArray'],
         "some.js": ['Promise', 'Promise$_All', 'PromiseArray', 'apiRejection'],
         "progress.js": ['Promise', 'isPromiseArrayProxy'],
-        "cancel.js": ['Promise', 'INTERNAL'],
+        "cancel.js": ['Promise'],
         "synchronous_inspection.js": ['Promise']
 
     };

--- a/src/cancel.js
+++ b/src/cancel.js
@@ -1,5 +1,6 @@
 "use strict";
-module.exports = function(Promise, INTERNAL) {
+module.exports = function(Promise) {
+    var INTERNAL = require("./util.js").INTERNAL;
     var errors = require("./errors.js");
     var async = require("./async.js");
     var ASSERT = require("./assert.js");

--- a/src/generators.js
+++ b/src/generators.js
@@ -1,6 +1,6 @@
 "use strict";
-module.exports = function(Promise, apiRejection, INTERNAL) {
-    var PromiseSpawn = require("./promise_spawn.js")(Promise, INTERNAL);
+module.exports = function(Promise, apiRejection) {
+    var PromiseSpawn = require("./promise_spawn.js")(Promise);
     var errors = require("./errors.js");
     var TypeError = errors.TypeError;
 

--- a/src/promise.js
+++ b/src/promise.js
@@ -6,11 +6,11 @@ var util = require("./util.js");
 var async = require("./async.js");
 var errors = require("./errors.js");
 
-var INTERNAL = function(){};
+var INTERNAL = util.INTERNAL;
 var APPLY = {};
 var NEXT_FILTER = {e: null};
 
-var PromiseArray = require("./promise_array.js")(Promise, INTERNAL);
+var PromiseArray = require("./promise_array.js")(Promise);
 var CapturedTrace = require("./captured_trace.js")();
 var CatchFilter = require("./catch_filter.js")(NEXT_FILTER);
 var PromiseResolver = require("./promise_resolver.js");

--- a/src/promise_array.js
+++ b/src/promise_array.js
@@ -1,8 +1,9 @@
 "use strict";
-module.exports = function(Promise, INTERNAL) {
+module.exports = function(Promise) {
 var ASSERT = require("./assert.js");
 var ensureNotHandled = require("./errors.js").ensureNotHandled;
 var util = require("./util.js");
+var INTERNAL = util.INTERNAL;
 var async = require("./async.js");
 var hasOwn = {}.hasOwnProperty;
 var isArray = util.isArray;

--- a/src/promise_spawn.js
+++ b/src/promise_spawn.js
@@ -1,9 +1,10 @@
 "use strict";
-module.exports = function(Promise, INTERNAL) {
+module.exports = function(Promise) {
 var errors = require("./errors.js");
 var TypeError = errors.TypeError;
 var ensureNotHandled = errors.ensureNotHandled;
 var util = require("./util.js");
+var INTERNAL = util.INTERNAL;
 var isArray = util.isArray;
 var errorObj = util.errorObj;
 var tryCatch1 = util.tryCatch1;

--- a/src/promisify.js
+++ b/src/promisify.js
@@ -1,7 +1,8 @@
 "use strict";
-module.exports = function(Promise, INTERNAL) {
+module.exports = function(Promise) {
 var THIS = {};
 var util = require("./util.js");
+var INTERNAL = util.INTERNAL;
 var es5 = require("./es5.js");
 var errors = require("./errors.js");
 var nodebackForPromise = require("./promise_resolver.js")

--- a/src/race.js
+++ b/src/race.js
@@ -1,7 +1,9 @@
 "use strict";
-module.exports = function(Promise, INTERNAL) {
+module.exports = function(Promise) {
     var apiRejection = require("./errors_api_rejection.js")(Promise);
-    var isArray = require("./util.js").isArray;
+    var util = require("./util.js");
+    var isArray = util.isArray;
+    var INTERNAL = util.INTERNAL;
 
     var raceLater = function Promise$_raceLater(promise) {
         return promise.then(function Promise$_lateRacer(array) {

--- a/src/timers.js
+++ b/src/timers.js
@@ -21,8 +21,9 @@ global.setTimeout( function(_) {
     }
 }, 1, pass);
 
-module.exports = function(Promise, INTERNAL) {
+module.exports = function(Promise) {
     var util = require("./util.js");
+    var INTERNAL = util.INTERNAL;
     var ASSERT = require("./assert.js");
     var apiRejection = require("./errors_api_rejection")(Promise);
     var TimeoutError = Promise.TimeoutError;

--- a/src/util.js
+++ b/src/util.js
@@ -195,7 +195,8 @@ var ret = {
     withAppended: withAppended,
     asString: asString,
     maybeWrapAsError: maybeWrapAsError,
-    wrapsPrimitiveReceiver: wrapsPrimitiveReceiver
+    wrapsPrimitiveReceiver: wrapsPrimitiveReceiver,
+    INTERNAL: function() {}
 };
 
 module.exports = ret;


### PR DESCRIPTION
Allows for library authors to access `INTERNAL` if they wish to make their own promise methods and use the `INTERNAL` property as it's used in the rest of the library (for example, I could write the method in #46 standalone in my own copy of Bluebird if I wanted).
