### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ A single cohesive guide compiled from the articles will probably be done eventua
 
 #License
 
-Copyright (c) 2013 Petka Antonov
+Copyright (c) 2014 Petka Antonov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The copyright year in the README was also out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
