### PR TITLE
clear out ref to promise after resolver has completed

### DIFF
--- a/src/promise_resolver.js
+++ b/src/promise_resolver.js
@@ -27,6 +27,10 @@ function wrapAsRejectionError(obj) {
 
 function nodebackForPromise(promise) {
     function PromiseResolver$_callback(err, value) {
+        if (promise === null) {
+            return;
+        }
+
         if (err) {
             var wrapped = wrapAsRejectionError(maybeWrapAsError(err));
             promise._attachExtraTrace(wrapped);
@@ -41,6 +45,8 @@ function nodebackForPromise(promise) {
                 promise._fulfill(value);
             }
         }
+
+        promise = null;
     }
     return PromiseResolver$_callback;
 }


### PR DESCRIPTION
Not sure about the "correctness" of this commit.  Can a `nodebackForPromise` fn be called more than once?

In any case, I was doing some heap inspecting of my app which heavily utilizes bluebird and was noticing that promises (and their fulfillment values and errors) were hanging around.  Walking the retaining tree in `node-webkit-agent`, I noticed that the ref was held only by bluebird internal fn's.

After making this change, the promises were gc'ed immediately.

node v0.10.15
