### PR TITLE
Checking for MutationObserver not in global

### DIFF
--- a/src/schedule.js
+++ b/src/schedule.js
@@ -8,9 +8,9 @@ if (typeof process !== "undefined" && process !== null &&
 
     schedule = process.nextTick;
 }
-else if ((typeof MutationObserver === "function" ||
-        typeof WebkitMutationObserver === "function" ||
-        typeof WebKitMutationObserver === "function") &&
+else if ((typeof global.MutationObserver === "function" ||
+        typeof global.WebkitMutationObserver === "function" ||
+        typeof global.WebKitMutationObserver === "function") &&
         typeof document !== "undefined" &&
         typeof document.createElement === "function") {
 
@@ -71,11 +71,11 @@ else if (typeof global.postMessage === "function" &&
 
     })();
 }
-else if (typeof MessageChannel === "function") {
+else if (typeof global.MessageChannel === "function") {
     schedule = (function(){
         var queuedFn = void 0;
 
-        var channel = new MessageChannel();
+        var channel = new global.MessageChannel();
         channel.port1.onmessage = function Promise$_Scheduler() {
                 ASSERT(queuedFn !== void 0);
                 var fn = queuedFn;


### PR DESCRIPTION
At the moment the scheduler checks MutationObserver and then assigning global.MutationObserver - causes a lot of **fun** in IE 11 extensions.

Also, @stefanpenner warned me IE10 does strange things when using MutationObserver:

http://codeforhire.com/2013/09/21/setimmediate-and-messagechannel-broken-on-internet-explorer-10/

https://github.com/cujojs/when/issues/197

To be fair, I haven't run into any issues myself running promises on the page, but then again I did not run it with spin.js - I'll try to reproduce
