### PR TITLE
Remove describe.only as it blocks other tests to run

### DIFF
--- a/test/mocha/schedule.js
+++ b/test/mocha/schedule.js
@@ -2,7 +2,7 @@ var assert   = require("assert");
 var schedule = require("../../js/debug/schedule");
 var isNodeJS = typeof process !== "undefined" && typeof process.execPath === "string";
 
-describe.only("schedule", function () {
+describe("schedule", function () {
     if (isNodeJS) {
         describe("for Node.js", function () {
             it("should preserve the active domain", function (done) {


### PR DESCRIPTION
I used it to filter out other tests to speed up the development, but forgot to remove before i had sent previous PR to fix the issue with process.nextTick. My bad.
