### PR TITLE
Wrap global.setTimeout to work with mocks

### DIFF
--- a/src/timers.js
+++ b/src/timers.js
@@ -17,7 +17,9 @@ var setTimeout = function(fn, time) {
 var pass = {};
 global.setTimeout( function(_) {
     if(_ === pass) {
-        setTimeout = global.setTimeout;
+      setTimeout = function() {
+        global.setTimeout.apply(void 0, arguments);
+      };
     }
 }, 1, pass);
 


### PR DESCRIPTION
When a mock testing library (like sinonjs) override global.setTimeout, bluebird
was keeping the original version and was not using the mocked one.
By wrapping the call to global.setTimeout, bluebird will always use the
correct setTimeout implementation.
