### PR TITLE
Easier way to run tests?

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--recursive
+--require test/mocha/helpers/exposeBluebird.js
+--reporter spec
+--timeout 500

--- a/test/mocha/helpers/exposeBluebird.js
+++ b/test/mocha/helpers/exposeBluebird.js
@@ -1,0 +1,1 @@
+global.adapter = require("../../../js/debug/bluebird.js");


### PR DESCRIPTION
Please don't merge this.

It's just an idea since I'm unable to run the tests (even from a clean repo). I guess this is some sort of beginner's mistake but the test-section in CONTRIBUTING.md is empty...

When I run "npm test" I get loads of errors such as the one below. With this pull request it's possible to run the tests with "mocha --harmony" which will run them sequentially but which, at least for me, runs most of the tests successfully.

I guess what I'm trying to say is that it would be nice to have that testing-section filled in :)

```
Running test mocha/3.2.1.js
Possibly unhandled Error: [object Object]
From previous event:
    at Promise$Resolve (/Users/gabrielf/Projects/bluebird/js/debug/promise.js:214:9)
    at Context.<anonymous> (/Users/gabrielf/Projects/bluebird/test/mocha/helpers/testThreeCases.js:10:14)
    at Test.Runnable.run (/Users/gabrielf/Projects/bluebird/node_modules/mocha/lib/runnable.js:194:15)
    at Runner.runTest (/Users/gabrielf/Projects/bluebird/node_modules/mocha/lib/runner.js:355:10)
    at /Users/gabrielf/Projects/bluebird/node_modules/mocha/lib/runner.js:401:12
    at next (/Users/gabrielf/Projects/bluebird/node_modules/mocha/lib/runner.js:281:14)
    at /Users/gabrielf/Projects/bluebird/node_modules/mocha/lib/runner.js:290:7
    at next (/Users/gabrielf/Projects/bluebird/node_modules/mocha/lib/runner.js:234:23)
    at Object._onImmediate (/Users/gabrielf/Projects/bluebird/node_modules/mocha/lib/runner.js:258:5)
```
