### PR TITLE
Promise#nodeify should not pass  as an explicit argument to a Node.js continuation callback

### DIFF
--- a/src/nodeify.js
+++ b/src/nodeify.js
@@ -14,17 +14,9 @@ function thrower(r) {
 function Promise$_successAdapter(val, receiver) {
     var nodeback = this;
     ASSERT(typeof nodeback == "function");
-    var ret;
-    if (val === undefined) {
-        // got no result, or result value is undefined.
-        //   ensure that the nodeback receives (arguments.length === 1),
-        //   since there is 'no result'.  arguments[1] will still be undefined.
-        ret = tryCatch1(nodeback, receiver, null);
-    }
-    else {
-        // provide the result value
-        ret = tryCatch2(nodeback, receiver, null, val);
-    }
+    var ret = val === void 0
+        ? tryCatch1(nodeback, receiver, null)
+        : tryCatch2(nodeback, receiver, null, val);
     if (ret === errorObj) {
         async.invokeLater(thrower, void 0, ret.e);
     }

--- a/test/mocha/q_nodeify.js
+++ b/test/mocha/q_nodeify.js
@@ -119,7 +119,7 @@ describe("nodeify", function () {
             sinon.assert.calledOnce(spy);
             sinon.assert.calledWithExactly(spy, null);
             done();
-        }, 100);
+        }, 10);
     });
 
     it("calls back with an error", function () {


### PR DESCRIPTION
a fix for [Issue #170](https://github.com/petkaantonov/bluebird/issues/170)

i am seeing this issue in 1.2.1.  it's easiest to describe via assertion

``` javascript
'use strict';

var assert = require('assert');
var Promise = require('bluebird');

describe('Promise', function() {
    describe('#nodeify', function() {
        it('receives an undefined result argument', function(done) {
            Promise.resolve().nodeify(function() {
                // a both a null Error and an undefined result are provided.
                assert.equal(2, arguments.length);
                assert.strictEqual(null, arguments[0]);
                assert.strictEqual(undefined, arguments[1]);

                // frameworks such as async will see `undefined` as an actual result value
                //   and honor it accordingly.  there are side-effects in the case of async.waterfall,
                //   where the `callback` provided to a series function will become the 2nd argument,
                //   since the 1st argument is the `undefined` result value handed downstream by #nodeify.
                // it would be more backward-compatible for #nodeify to provide a 1-argument signature --
                //   `(null)` as filler for the missing Error -- to the Node.js continuation callback
                //   when the upstream result value is `undefined`.
                done();
            });
        });
    });
});
```
