### PR TITLE
Fix breaking change to Firefox extensions

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -1,8 +1,12 @@
 module.exports = (function() {
-    if (this !== void 0) return this;
-    try {return global;}
+    if (this !== void 0) return this; //nonstrict mode
+    try {return global;} // node
     catch(e) {}
-    try {return window;}
+    try {
+        // firefox extension, strict mode
+        if(window.wrappedJSObject !== void 0) return window.wrappedJSObject; 
+        return window; // browser
+    }
     catch(e) {}
     try {return self;}
     catch(e) {}


### PR DESCRIPTION
https://github.com/petkaantonov/bluebird/commit/e6bd2e014b36e0ab94b7ae204bd7a131e0e2f4f2#diff-026e6ee461445a75dbf07f09752148bd broke https://github.com/petkaantonov/bluebird/commit/efc82a11ffa9703bf3ceaf81432853206651b497 

In firefox extensions you can still access the global scope through window with `window.wrappedJSObject`. When we detect global - we now check for this.
