### PR TITLE
Clarify .spread tip in example

### DIFF
--- a/API.md
+++ b/API.md
@@ -903,7 +903,7 @@ Use [`.spread`](#spreadfunction-fulfilledhandler--function-rejectedhandler----pr
 ```js
 var Promise = require("bluebird");
 var request = Promise.promisify(require('request'));
-request("http://www.google.com").spread(function(request, body) {
+request("http://www.google.com").spread(function(req, body) {
     console.log(body);
 }).catch(function(err) {
     console.error(err);


### PR DESCRIPTION
Naming the parameter `request` could lead to confusion and possible unexpected behavior since there is already a `request` module defined.
