### PR TITLE
using wrong all method for rsvp

### DIFF
--- a/benchmark/madeup-parallel/promises-tildeio-rsvp.js
+++ b/benchmark/madeup-parallel/promises-tildeio-rsvp.js
@@ -12,7 +12,7 @@ module.exports = function upload(stream, idOrPath, tag, done) {
         queries[i] = FileVersion.insert({index: i}).execWithin(tx);
     }
 
-    RSVP.Promise.all(queries).then(function() {
+    RSVP.all(queries).then(function() {
         tx.commit();
         done();
     }, function(err) {


### PR DESCRIPTION
in the parrallel test (but not the others) a depreciated method was used that seems to have been taken out of newer versions.
