### PR TITLE
Restore 'deprecated' function in util.js.

### DIFF
--- a/js/browser/bluebird.js
+++ b/js/browser/bluebird.js
@@ -4887,6 +4887,12 @@ var haveGetters = (function(){
     }
 
 })();
+function deprecated(msg) {
+    if (typeof console !== "undefined" && console !== null &&
+        typeof console.warn === "function") {
+        console.warn("Bluebird: " + msg);
+    }
+}
 var canEvaluate = typeof navigator == "undefined";
 var errorObj = {e: {}};
 function tryCatch1(fn, receiver, arg) {
@@ -5100,6 +5106,7 @@ var ret = {
     isPrimitive: isPrimitive,
     isObject: isObject,
     canEvaluate: canEvaluate,
+    deprecated: deprecated,
     errorObj: errorObj,
     tryCatch1: tryCatch1,
     tryCatch2: tryCatch2,

--- a/src/util.js
+++ b/src/util.js
@@ -16,6 +16,12 @@ var haveGetters = (function(){
     }
 
 })();
+function deprecated(msg) {
+    if (typeof console !== "undefined" && console !== null &&
+        typeof console.warn === "function") {
+        console.warn("Bluebird: " + msg);
+    }
+}
 // Assume CSP if browser
 var canEvaluate = typeof navigator == "undefined";
 var errorObj = {e: {}};
@@ -235,6 +241,7 @@ var ret = {
     isPrimitive: isPrimitive,
     isObject: isObject,
     canEvaluate: canEvaluate,
+    deprecated: deprecated,
     errorObj: errorObj,
     tryCatch1: tryCatch1,
     tryCatch2: tryCatch2,


### PR DESCRIPTION
`util.deprecated` is still used in [generators.js](https://github.com/petkaantonov/bluebird/blob/master/src/generators.js#L126). It was improperly removed in 000fc8543a2f57f4df2934ab0bdd3e9d722364e4. Without this patch, use of `Promise.spawn()` will cause the following error:

```
TypeError: undefined is not a function
    at Promise$Spawn (project/node_modules/bluebird/js/main/generators.js:142:5)
   ...
```
