### PR TITLE
Support promisify(obj, string) promisify shorthand.

### DIFF
--- a/API.md
+++ b/API.md
@@ -1467,6 +1467,15 @@ redisGet('foo').then(function() {
 });
 ```
 
+Optionally, you may use the following shorthand to maintain context: 
+
+```js
+var redisGet = Promise.promisify(redisClient, 'get');
+redisGet('foo').then(function() {
+    //...
+});
+```
+
 **Tip**
 
 Use [`.spread`](#spreadfunction-fulfilledhandler--function-rejectedhandler----promise) with APIs that have multiple success values:

--- a/js/browser/bluebird.js
+++ b/js/browser/bluebird.js
@@ -3579,6 +3579,11 @@ function promisify(callback, receiver) {
 }
 
 Promise.promisify = function Promise$Promisify(fn, receiver) {
+    if (typeof receiver === "string") {
+        var prop = receiver;
+        receiver = fn;
+        fn = receiver[prop];
+    }
     if (typeof fn !== "function") {
         throw new TypeError("fn must be a function");
     }

--- a/src/promisify.js
+++ b/src/promisify.js
@@ -274,6 +274,11 @@ function promisify(callback, receiver) {
 }
 
 Promise.promisify = function Promise$Promisify(fn, receiver) {
+    if (typeof receiver === "string") {
+        var prop = receiver;
+        receiver = fn;
+        fn = receiver[prop];
+    }
     if (typeof fn !== "function") {
         throw new TypeError(NOT_FUNCTION_ERROR);
     }

--- a/test/mocha/promisify.js
+++ b/test/mocha/promisify.js
@@ -808,3 +808,21 @@ if (canTestArity) {
         })
     })
 }
+
+describe("promisify with object and string argument", function() {
+    var o = {
+        value: 15,
+
+        f: function(a, cb) {
+            cb(null, a + this.value);
+        }
+    };
+    var prom = Promise.promisify(o, "f");
+
+    specify("should properly bind function with receiver", function(done) {
+        prom(5).then(function(val){
+            assert.equal(val, 20);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Occasionally, I need to `promisify` functions that are within deep objects or otherwise have long names, and need to maintain their context. Sometimes it is nice to avoid `promisifyAll` for performance reasons.

This PR allows the shorthand:

``` javascript
var fn = Promise.promisify(a.deep.nested.object, 'aFunction');
```

Instead of the current

``` javascript
var fn = Promise.promisify(a.deep.nested.object.aFunction, a.deep.nested.object);
```

I have added some basic documentation of the change in `API.md` but I am unsure how to document the parameters.
