### PR TITLE
Update browserify to 4.2.0, which renames internal require.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "jquery-browserify": "~1.8.1",
         "sinon": "~1.7.3",
         "kew": "~0.2.2",
-        "browserify": "~2.35.0",
+        "browserify": "~4.2.0",
         "concurrent": "~0.3.2",
         "text-table": "~0.2.0",
         "grunt-cli": "~0.1.9",


### PR DESCRIPTION
This updates browserify to 4.2.x, which brings uses [derequire](https://github.com/calvinmetcalf/derequire) when using the `--standalone` option. Using `require` inside a standalone build usually throws off AMD loaders like Require.js.

The tests continue to pass and the only diff in the build is replacing internal `require`s with `_dereq_`.
