### PR TITLE
Upgrade Travis CI Badge to SVG. Add DavidDM Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/petkaantonov/bluebird.png?branch=master)](https://travis-ci.org/petkaantonov/bluebird)
+[![Build Status](https://travis-ci.org/petkaantonov/bluebird.svg?branch=master)](https://travis-ci.org/petkaantonov/bluebird) [![Dependency Status](https://david-dm.org/petkaantonov/bluebird.svg)](https://david-dm.org/petkaantonov/bluebird) [![devDependency Status](https://david-dm.org/petkaantonov/bluebird/dev-status.svg)](https://david-dm.org/petkaantonov/bluebird#info=devDependencies)
 
 <a href="http://promisesaplus.com/">
     <img src="http://promisesaplus.com/assets/logo-small.png" alt="Promises/A+ logo"


### PR DESCRIPTION
Props totally go to @shinnn - though this should be a cleaner merge.

Using SVG Badges provides a clearer view for everyone (cough, retina display Macbookers... cough)
David-DM can be used to keep an eye on the npm dependencies that the project uses. The david tool from npm can also be used to automatically update dependencies listed in `package.json` to the latest version.
