### PR TITLE
Fix inconsistent require in API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -976,7 +976,7 @@ fs.readdirAsync(".").map(function(fileName) {
 Example of static map:
 
 ```js
-var Promise = require("./js/main/bluebird.js");
+var Promise = require("bluebird");
 var join = Promise.join;
 var fs = Promise.promisifyAll(require("fs"));
 


### PR DESCRIPTION
One of the require statements was `require("./js/main/bluebird.js")`
instead of `require('bluebird')`. Changed it to be more consistent with
the rest of the require statements.
