### PR TITLE
fixes error cutoff issue #276

### DIFF
--- a/src/captured_trace.js
+++ b/src/captured_trace.js
@@ -101,7 +101,7 @@ CapturedTrace.combine = function CapturedTrace$Combine(current, prev) {
     //that nobody cares about
     for (var i = 0, len = lines.length; i < len; ++i) {
 
-        if ((rignore.test(lines[i]) ||
+        if (((rignore.test(lines[i]) && rtraceline.test(lines[i])) ||
             (i > 0 && !rtraceline.test(lines[i])) &&
             lines[i] !== FROM_PREVIOUS_EVENT)
        ) {

--- a/test/mocha/github-2xx-76.js
+++ b/test/mocha/github-2xx-76.js
@@ -1,0 +1,18 @@
+"use strict";
+
+
+var Promise = require("../../js/debug/bluebird.js");
+Promise.longStackTraces();
+var assert = require("assert");
+
+describe("github276 - stack trace cleaner", function(){
+    specify("message with newline and a$_b should not be removed", function(done){
+        Promise.resolve(1).then(function() {
+            throw new Error("Blah\n          a$_b");
+        }).catch(function(e) {
+            var msg = e.stack.split('\n')[1]
+            assert(msg.indexOf('a$_b') >= 0, 'message should contain a$_b');
+        }).done(done, done);
+    });
+});
+


### PR DESCRIPTION
This fixes #276

Note: the tests `when_map.js` and `when_reduce.js` never complete, so this pull request may still be having some problems

Assertion that gets stuck in when_map.js:

"should map input when mapper returns a promise with concurrency:"

Assertion that gets stuck in when_reduce.js:

"should reduce in input order:"

Edit: these are probably unrelated to the PR, as the same thing happens when I run the tests on current master
