### PR TITLE
Cross-instance disposers and disposable promises

### DIFF
--- a/test/mocha/using.js
+++ b/test/mocha/using.js
@@ -2,6 +2,7 @@
 var assert = require("assert");
 
 var Promise = require("../../js/debug/bluebird.js");
+var Promise2 = require("../../js/debug/promise.js")();
 
 var using = Promise.using;
 var delay = Promise.delay;
@@ -205,4 +206,16 @@ describe("Promise.using", function() {
             done();
         });
     });
+
+    specify("with using comming from another Promise instance", function(done) {
+        var res;
+        Promise2.using(connect(), function(connection){
+            res = connection;
+        }).then(function() {
+            assert(res.isClosed);
+            assert.equal(res.closesCalled, 1);
+            done();
+        });
+    });
+
 })


### PR DESCRIPTION
This patch makes disposers and disposable promises work across bluebird
instances. The instanceof Disposer check was replaced with a duck
typing check and a new local cast function that preserves the
disposable property (as well as the disposer) was added.

Should fix #260
