### PR TITLE
Add a prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "fluent interface"
     ],
     "scripts": {
-        "test": "grunt test"
+        "test": "grunt test",
+        "prepublish": "grunt build"
     },
     "homepage": "https://github.com/petkaantonov/bluebird",
     "repository": {


### PR DESCRIPTION
I couldn't find a documented release process so apologies if this has already been discussed.

I would like bluebird to define a "prepublish" script that runs the default build so that `npm install petkaantonov/bluebird#{commit-ish}` will work correctly. Despite being somewhat unintuitive, this is the recommended/only way to accomplish that goal.
