### PR TITLE
fixed map order

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -5,7 +5,7 @@ var tryCatch3 = util.tryCatch3;
 var errorObj = util.errorObj;
 var PENDING = {};
 var EMPTY_ARRAY = [];
-p
+
 function MappingPromiseArray(promises, fn, limit, _filter) {
     this.constructor$(promises);
     this._callback = fn;


### PR DESCRIPTION
This becomes noticeable when you set the `concurrency` option. The first items start in the correct order and then all other items are reversed because its using a `.pop()` to drain the queue.
