### PR TITLE
fix; lower attachment count

### DIFF
--- a/src/call_get.js
+++ b/src/call_get.js
@@ -43,8 +43,8 @@ function getCompiled(name, compiler, cache) {
         cache[" size"]++;
         if (cache[" size"] > 512) {
             var keys = Object.keys(cache);
-            for (var i = 0; i < 4; ++i) delete cache[keys[i]];
-            cache[" size"] = keys.length - 4;
+            for (var i = 0; i < 256; ++i) delete cache[keys[i]];
+            cache[" size"] = keys.length - 256;
         }
     }
     return ret;


### PR DESCRIPTION
This fixes the issue discovered in #296 by lowering the number of
interactions a promise has to have before it's cleaned up.
