### PR TITLE
Fixed a recurring typo in the API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -958,7 +958,7 @@ Promise.some(...)
 
 #####`.map(Function mapper [, Object options])` -> `Promise`
 
-Map an array, or a promise of an array, which contains a promises (or a mix of promises and values) with the given `mapper` function with the signature `(item, index, arrayLength)` where `item` is the resolved value of a respective promise in the input array. If any promise in the input array is rejected the returned promise is rejected as well.
+Map an array, or a promise of an array, which contains promises (or a mix of promises and values) with the given `mapper` function with the signature `(item, index, arrayLength)` where `item` is the resolved value of a respective promise in the input array. If any promise in the input array is rejected the returned promise is rejected as well.
 
 The mapper function for a given item is called as soon as possible, that is, when the promise for that item's index in the input array is fulfilled. This doesn't mean that the result array has items in random order, it means that `.map` can be used for concurrency coordination unlike `.all().call("map", fn).all()`.
 
@@ -1068,7 +1068,7 @@ such concurrency
 
 #####`.reduce(Function reducer [, dynamic initialValue])` -> `Promise`
 
-Reduce an array, or a promise of an array, which contains a promises (or a mix of promises and values) with the given `reducer` function with the signature `(total, current, index, arrayLength)` where `item` is the resolved value of a respective promise in the input array. If any promise in the input array is rejected the returned promise is rejected as well.
+Reduce an array, or a promise of an array, which contains promises (or a mix of promises and values) with the given `reducer` function with the signature `(total, current, index, arrayLength)` where `item` is the resolved value of a respective promise in the input array. If any promise in the input array is rejected the returned promise is rejected as well.
 
 If the reducer function returns a promise or a thenable, the result for the promise is awaited for before continuing with next iteration.
 
@@ -1114,7 +1114,7 @@ See [`.map()`](#mapfunction-mapper--object-options---promise);
 
 #####`.each(Function iterator)` -> `Promise`
 
-Iterate over an array, or a promise of an array, which contains a promises (or a mix of promises and values) with the given `iterator` function with the signature `(item, index, value)` where `item` is the resolved value of a respective promise in the input array. If any promise in the input array is rejected the returned promise is rejected as well.
+Iterate over an array, or a promise of an array, which contains promises (or a mix of promises and values) with the given `iterator` function with the signature `(item, index, value)` where `item` is the resolved value of a respective promise in the input array. If any promise in the input array is rejected the returned promise is rejected as well.
 
 Resolves to the original array unmodified, this method is meant to be used for side effects. Items are called as soon as possible, in-order.
 


### PR DESCRIPTION
Yes, I forked the repo for a 6-character edit. But Github makes that sort of thing relatively painless. ;-)
