### PR TITLE
include js/browser in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "readmeFilename": "README.md",
     "main": "./js/main/bluebird.js",
     "files": [
+        "js/browser",
         "js/main",
         "js/zalgo",
         "LICENSE",


### PR DESCRIPTION
As mentioned in #322, include js/browser in the npm package.json files manifest so that npm can be used for the browser packages.
