### PR TITLE
fix #335 - dont replace plain args string - method may contain it

### DIFF
--- a/src/promisify.js
+++ b/src/promisify.js
@@ -124,26 +124,26 @@ function makeNodePromisifiedEval(callback, receiver, originalName, fn, suffix) {
         var ret;
         if (typeof callback === "string") {
             ret = "                                                          \n\
-                this.method(args, fn);                                       \n\
+                this.method({{args}}, fn);                                   \n\
                 break;                                                       \n\
             ".replace(".method", generatePropertyAccess(callback));
         } else if (receiver === THIS) {
             ret =  "                                                         \n\
-                callback.call(this, args, fn);                               \n\
+                callback.call(this, {{args}}, fn);                           \n\
                 break;                                                       \n\
             ";
         } else if (receiver !== void 0) {
             ret =  "                                                         \n\
-                callback.call(receiver, args, fn);                           \n\
+                callback.call(receiver, {{args}}, fn);                       \n\
                 break;                                                       \n\
             ";
         } else {
             ret =  "                                                         \n\
-                callback(args, fn);                                          \n\
+                callback({{args}}, fn);                                      \n\
                 break;                                                       \n\
             ";
         }
-        return ret.replace("args", args).replace(", ", comma);
+        return ret.replace("{{args}}", args).replace(", ", comma);
     }
 
     function generateArgumentSwitchCase() {

--- a/test/mocha/promisify.js
+++ b/test/mocha/promisify.js
@@ -394,6 +394,22 @@ describe("promisify on objects", function(){
             done();
         });
     });
+
+
+    specify("gh335", function(done) {
+        function HasArgs() { }
+        HasArgs.prototype.args = function(cb) {
+            return cb(null, "ok");
+        };
+
+        Promise.promisifyAll(HasArgs.prototype);
+        var a = new HasArgs();
+        a.argsAsync().then(function(res) {
+            assert.equal(res, "ok");
+            done();
+        });
+    });
+    
 });
 
 describe( "Promisify with custom suffix", function() {


### PR DESCRIPTION
promisifyAll  breaks if a method name contains "args" - this patch fixes that
