### PR TITLE
Document serial nature of .each more explicitly

### DIFF
--- a/API.md
+++ b/API.md
@@ -1152,7 +1152,7 @@ See [`.map()`](#mapfunction-mapper--object-options---promise);
 
 #####`.each(Function iterator)` -> `Promise`
 
-Iterate over an array, or a promise of an array, which contains promises (or a mix of promises and values) with the given `iterator` function with the signature `(item, index, value)` where `item` is the resolved value of a respective promise in the input array. If any promise in the input array is rejected the returned promise is rejected as well.
+Iterate over an array, or a promise of an array, which contains promises (or a mix of promises and values) with the given `iterator` function with the signature `(item, index, value)` where `item` is the resolved value of a respective promise in the input array. Iteration happens in serially. If any promise in the input array is rejected the returned promise is rejected as well.
 
 Resolves to the original array unmodified, this method is meant to be used for side effects. If the iterator function returns a promise or a thenable, the result for the promise is awaited for before continuing with next iteration.
 


### PR DESCRIPTION
In issue #134, I learned more about different ways to achieve something like `mapSeries` with bluebird.  I had previously read the docs for `.each`, but it wasn't clear to me from the docs that it operated serially.  Just add a quick note to make that clear for any others like me who were searching for some serial method.
