### PR TITLE
Promise.method : 0 arguments.length should remain 0

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -21,6 +21,7 @@ var CatchFilter = require("./catch_filter.js")(NEXT_FILTER);
 var PromiseResolver = require("./promise_resolver.js");
 var isArray = util.isArray;
 var errorObj = util.errorObj;
+var tryCatch0 = util.tryCatch0;
 var tryCatch1 = util.tryCatch1;
 var tryCatch2 = util.tryCatch2;
 var tryCatchApply = util.tryCatchApply;
@@ -191,7 +192,7 @@ Promise.method = function (fn) {
     return function () {
         var value;
         switch(arguments.length) {
-        case 0: value = tryCatch1(fn, this, undefined); break;
+        case 0: value = tryCatch0(fn, this); break;
         case 1: value = tryCatch1(fn, this, arguments[0]); break;
         case 2: value = tryCatch2(fn, this, arguments[0], arguments[1]); break;
         default:

--- a/src/util.js
+++ b/src/util.js
@@ -21,6 +21,14 @@ var canEvaluate = typeof navigator == "undefined";
 var errorObj = {e: {}};
 //Try catch is not supported in optimizing
 //compiler, so it is isolated
+function tryCatch0(fn, receiver) {
+    try { return fn.call(receiver); }
+    catch (e) {
+        errorObj.e = e;
+        return errorObj;
+    }
+}
+
 function tryCatch1(fn, receiver, arg) {
     try { return fn.call(receiver, arg); }
     catch (e) {
@@ -244,6 +252,7 @@ var ret = {
     isObject: isObject,
     canEvaluate: canEvaluate,
     errorObj: errorObj,
+    tryCatch0: tryCatch0,
     tryCatch1: tryCatch1,
     tryCatch2: tryCatch2,
     tryCatch3: tryCatch3,

--- a/test/mocha/method.js
+++ b/test/mocha/method.js
@@ -121,4 +121,12 @@ describe("Promise.method", function(){
             done();
         });
     });
+
+    specify("zero arguments length should remain zero", function(done) {
+
+        Promise.method(function(){
+            assert(arguments.length === 0);
+            done();
+        })();
+    });
 });


### PR DESCRIPTION
I just hit this issue in my project. If you call a Promise.method function without arguments, its arguments.length is 1.