### PR TITLE
Readme: fix line-through on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-[![Build Status](https://travis-ci.org/petkaantonov/bluebird.svg?branch=master)](https://travis-ci.org/petkaantonov/bluebird)
-
 <a href="http://promisesaplus.com/">
     <img src="http://promisesaplus.com/assets/logo-small.png" alt="Promises/A+ logo"
          title="Promises/A+ 1.1 compliant" align="right" />
 </a>
-
+[![Build Status](https://travis-ci.org/petkaantonov/bluebird.svg?branch=master)](https://travis-ci.org/petkaantonov/bluebird)
 
 
 #Introduction


### PR DESCRIPTION
GitHub's Markdown rendering puts a border line below the headline.
Unfortunately, that stroke through the "then" badge. Raising it above
the build status or same height should fix this.