### PR TITLE
Fix captured trace length issue when decycling

### DIFF
--- a/src/captured_trace.js
+++ b/src/captured_trace.js
@@ -20,13 +20,17 @@ inherits(CapturedTrace, Error);
 CapturedTrace.prototype.uncycle = function() {
     var length = this._length;
     if (length < 2) return;
-    var nodes = new Array(length);
+    var nodes = [];
     var stackToIndex = {};
 
     for (var i = 0, node = this; node !== undefined; ++i) {
-        nodes[i] = node;
+        nodes.push(node);
         node = node._parent;
     }
+    // the node length is only used as heuristic to decide when to decycle, as
+    // there may be multiple linked lists that share members and decycling one
+    // will fail to update lenghts in the other. This is the correct length.
+    length = this._length = i;
     ASSERT(nodes[0] === this);
     ASSERT(nodes[nodes.length - 1] instanceof CapturedTrace);
 


### PR DESCRIPTION
Motivating example

If a chain of traces is made that looks like this

    c -> b -> a

then you add `d` and `e` to form two chains

    d -> c -> b -> a,
    e -> c -> b -> a

decycling from d will not update the length of e (and lead to a crash when `e.decycle()` is called later)

This patch fixes that by not relying on that length for anything else
except as a heuristic whether to decycle or not