### PR TITLE
Correct spelling of 'unhandled'

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -89,7 +89,7 @@ CONSTANT(QUEUE_MIN_CAPACITY, 16);
 
 //captured_trace.js
 CONSTANT(FROM_PREVIOUS_EVENT, "From previous event:");
-CONSTANT(UNHANDLED_REJECTION_HEADER, "Possibly unhanded ");
+CONSTANT(UNHANDLED_REJECTION_HEADER, "Possibly unhandled ");
 CONSTANT(NEWLINE_PROTECTOR, "\\u0002\\u0000\\u0001");
 
 //direct_resolve.js


### PR DESCRIPTION
I'm not sure if 'unhanded' means something and this actually was correct. I would expect it to not be handled, e.g. 'unhandled'.