### PR TITLE
fix Promise.map execute order

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -102,7 +102,7 @@ MappingPromiseArray.prototype._drainQueue = function () {
     var values = this._values;
     while (queue.length > 0 && this._inFlight < limit) {
         if (this._isResolved()) return;
-        var index = queue.pop();
+        var index = queue.shift();
         this._promiseFulfilled(values[index], index);
     }
 };

--- a/test/mocha/when_map.js
+++ b/test/mocha/when_map.js
@@ -409,7 +409,7 @@ describe("when.map-test with concurrency", function () {
             });
         }, {concurrency: 5}).then(function() {
             assert(wasEmpty);
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6, 5]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
             done();
         });
 


### PR DESCRIPTION
demo.js
```js
global.Promise = require('bluebird');

function echoAsync (i) {
  var d = Promise.defer();
  setTimeout(function() {
    console.log("echoing %d",i);
    d.resolve();
  },1000);
  return d.promise;
}

Promise.map([1,2,3,4,5,6,7,8,9,10],function(i) {
  return echoAsync(i);
},{
  concurrency: 1
});
```

node demo.js results
```
echoing 1
echoing 10
echoing 9
echoing 8
echoing 7
echoing 6
echoing 5
echoing 4
echoing 3
echoing 2
```
this seems weird. I think we all prefer
```
echoing 1
echoing 2
echoing 3
echoing 4
echoing 5
echoing 6
echoing 7
echoing 8
echoing 9
echoing 10
```