### PR TITLE
Fix for scope-related issue with node-webkit

### DIFF
--- a/src/schedule.js
+++ b/src/schedule.js
@@ -2,7 +2,7 @@
 var schedule;
 if (typeof process === "object" && typeof process.version === "string") {
     schedule = parseInt(process.version.split(".")[1], 10) > 10
-        ? setImmediate : process.nextTick;
+        ? global.setImmediate : process.nextTick;
 }
 else if (typeof MutationObserver !== "undefined") {
     schedule = function(fn) {


### PR DESCRIPTION
There's a call to the function setImmediate() on schedule.js that breaks compatibility with the Node-Webkit runtime.

It seems that Node-Webkit combines part of node's global scope with the one used by Chromium. Because of this, some functions have to be called as attributes of the global variable.

I made the replacement, this should not break compatibility with Node but it would be good to give it a try just in case. 