### PR TITLE
Bug fix: process.version parsing error

### DIFF
--- a/src/schedule.js
+++ b/src/schedule.js
@@ -1,7 +1,7 @@
 "use strict";
 var schedule;
 if (require("./util.js").isNode) {
-    var version = process.version.split(".").map(Number);
+    var version = process.versions.node.split(".").map(Number);
     schedule = (version[0] === 0 && version[1] > 10) || (version[0] > 0)
         ? global.setImmediate : process.nextTick;
 }


### PR DESCRIPTION
This PR fixes a `process.version` parsing bug introduced in [this commit](https://github.com/petkaantonov/bluebird/commit/9fcbd99398dc5b8726fb4f1c6e20752e1b39e3e1). (broken since v2.9.3)

`process.version` returns a version string in the format `v0.12.0` rather than `0.12.0`. Since the first token from split returns a string `v0` rather than `0`, map function always maps it to `NaN`. As a result `version[0] === 0` test always fails and `process.nextTick` is always picked.

The suggested fix is to use `process.versions.node` as it returns a string in the format `0.12.0`. (also confirmed this value exists and works as expected in `io.js`.

Related issue: https://github.com/abbr/deasync/issues/2