### PR TITLE
connection pool 'close' method

### DIFF
--- a/API.md
+++ b/API.md
@@ -1300,8 +1300,8 @@ function getSqlConnection(connectionString) {
     return pg.connectAsync(connectionString).spread(function(client, done) {
         close = done;
         return client;
-    }).disposer(function(client) {
-        if (close) close(client);
+    }).disposer(function() {
+        if (close) close();
     });
 }
 


### PR DESCRIPTION
I just ran into a bug where my clients were being destroyed.  I pinned it down to this line of code.  According to:

https://github.com/brianc/node-postgres/wiki/pg#parameters

You should only pass a truthy value if you want the client to be destroyed and removed from the connection pool - which is not normally the case.  Even if it was the example's intent, you should simply pass in 'true' instead of the client, because it is misleading to the reader in what is actually going on.