### PR TITLE
Alias exec to nodeify

### DIFF
--- a/src/nodeify.js
+++ b/src/nodeify.js
@@ -43,6 +43,7 @@ function errorAdapter(reason, nodeback) {
     }
 }
 
+Promise.prototype.asCallback = 
 Promise.prototype.nodeify = function (nodeback, options) {
     if (typeof nodeback == "function") {
         var adapter = successAdapter;


### PR DESCRIPTION
I think nodeify is the only method in Bluebird I have issue with, is feels non-obvious compared to everything else - moreso now that there's probably a camp of people that might insist it be renamed `ioify` :P

But in all seriousness, it feels sort of clunky when a promise is exposed through library apis... 

```js
userModel.where('id', 1).fetchAll({withRelated: ['accounts']}).nodeify(cb)
```

"What's a nodeify? Why am I nodeifying a model?"

vs:

```js
userModel.where('id', 1).fetchAll({withRelated: ['accounts']}).exec(cb)
```

"Oh, execute the `fetchAll` with a callback"

I personally don't use callbacks here, but for those that do I think this offers a better UX - I believe mongoose uses `exec` as the method name for their callback handler which is where I originally got the naming.