### PR TITLE
Fix error when running in nw.js

### DIFF
--- a/src/schedule.js
+++ b/src/schedule.js
@@ -4,9 +4,15 @@ var noAsyncScheduler = function() {
     throw new Error(NO_ASYNC_SCHEDULER);
 };
 if (require("./util.js").isNode) {
-    var version = process.versions.node.split(".").map(Number);
-    schedule = (version[0] === 0 && version[1] > 10) || (version[0] > 0)
-        ? global.setImmediate : process.nextTick;
+    if (typeof process.versions["node-webkit"] !== "undefined") {
+        var version = process.versions["node-webkit"].split(".").map(Number);
+        schedule = (version[0] === 0 && version[1] > 8) || (version[0] > 0)
+            ? global.setImmediate : process.nextTick;
+    } else {
+        var version = process.versions.node.split(".").map(Number);
+        schedule = (version[0] === 0 && version[1] > 10) || (version[0] > 0)
+            ? global.setImmediate : process.nextTick;        
+    }
 
     if (!schedule) {
         if (typeof setImmediate !== "undefined") {

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -4,7 +4,7 @@ var noAsyncScheduler = function() {
     throw new Error(NO_ASYNC_SCHEDULER);
 };
 if (require("./util.js").isNode) {
-    if (typeof process.versions["node-webkit"] !== "undefined") {
+    if ("node-webkit" in process.versions) {
         var version = process.versions["node-webkit"].split(".").map(Number);
         schedule = (version[0] === 0 && version[1] > 8) || (version[0] > 0)
             ? global.setImmediate : process.nextTick;


### PR DESCRIPTION
Hi Petka,

I noticed an issue with running the latest version inside  nw.js (node-webkit). In schedule.js `process.versions.node` is assumed to exist. In node-webkit, however, it doesn't so the call to `process.versions.node.split(".")` fails.

Here's a pull request which I believe fixes the issue. In nw.js `process.versions["node-webkit"]` is used instead. As you can see from the nw.js changelog (https://github.com/nwjs/nw.js/blob/master/CHANGELOG.md), v0.9.0 of nw.js uses Node.js v0.11 so the new nwjs-related check compares against version 0.8 of nw.js.

Cheers,
Simon