### PR TITLE
Fix leaks from `tryCatchTarget`, `errorObj` and `NEXT_FILTER`

### DIFF
--- a/src/catch_filter.js
+++ b/src/catch_filter.js
@@ -39,7 +39,8 @@ CatchFilter.prototype.doFilter = function (e) {
         if (itemIsErrorType && e instanceof item) {
             var ret = tryCatch(cb).call(boundTo, e);
             if (ret === errorObj) {
-                NEXT_FILTER.e = ret.e;
+                NEXT_FILTER.e = errorObj.e;
+                errorObj.e = null;
                 return NEXT_FILTER;
             }
             return ret;
@@ -47,11 +48,13 @@ CatchFilter.prototype.doFilter = function (e) {
             var shouldHandle = safePredicate(item, e);
             if (shouldHandle === errorObj) {
                 e = errorObj.e;
+                errorObj.e = null;
                 break;
             } else if (shouldHandle) {
                 var ret = tryCatch(cb).call(boundTo, e);
                 if (ret === errorObj) {
-                    NEXT_FILTER.e = ret.e;
+                    NEXT_FILTER.e = errorObj.e;
+                    errorObj.e = null;
                     return NEXT_FILTER;
                 }
                 return ret;

--- a/src/generators.js
+++ b/src/generators.js
@@ -17,8 +17,10 @@ function promiseFromYieldHandler(value, yieldHandlers, traceParent) {
         var result = tryCatch(yieldHandlers[i])(value);
         traceParent._popContext();
         if (result === errorObj) {
+            var e = errorObj.e;
+            errorObj.e = null;
             traceParent._pushContext();
-            var ret = Promise.reject(errorObj.e);
+            var ret = Promise.reject(e);
             traceParent._popContext();
             return ret;
         }
@@ -53,7 +55,9 @@ PromiseSpawn.prototype._run = function () {
 
 PromiseSpawn.prototype._continue = function (result) {
     if (result === errorObj) {
-        return this._promise._rejectCallback(result.e, false, true);
+        var e = errorObj.e;
+        errorObj.e = null;
+        return this._promise._rejectCallback(e, false, true);
     }
 
     var value = result.value;

--- a/src/join.js
+++ b/src/join.js
@@ -51,7 +51,9 @@ if (canEvaluate) {
             var ret = tryCatch(handler)(this);
             promise._popContext();
             if (ret === errorObj) {
-                promise._rejectCallback(ret.e, false, true);
+                var e = errorObj.e;
+                errorObj.e = null;
+                promise._rejectCallback(e, false, true);
             } else {
                 promise._resolveCallback(ret);
             }

--- a/src/map.js
+++ b/src/map.js
@@ -64,7 +64,11 @@ MappingPromiseArray.prototype._promiseFulfilled = function (value, index) {
         this._promise._pushContext();
         var ret = tryCatch(callback).call(receiver, value, index, length);
         this._promise._popContext();
-        if (ret === errorObj) return this._reject(ret.e);
+        if (ret === errorObj) {
+            var e = errorObj.e;
+            errorObj.e = null;
+            return this._reject(e);
+        }
 
         // If the mapper function returned a promise we simply reuse
         // The MappingPromiseArray as a PromiseArray for round 2.

--- a/src/method.js
+++ b/src/method.js
@@ -38,7 +38,9 @@ Promise.attempt = Promise["try"] = function (fn, args, ctx) {
 Promise.prototype._resolveFromSyncValue = function (value) {
     ASSERT(!this._isFollowing());
     if (value === util.errorObj) {
-        this._rejectCallback(value.e, false, true);
+        var e = util.errorObj.e;
+        util.errorObj.e = null;
+        this._rejectCallback(e, false, true);
     } else {
         this._resolveCallback(value, true);
     }

--- a/src/nodeify.js
+++ b/src/nodeify.js
@@ -11,7 +11,9 @@ function spreadAdapter(val, nodeback) {
     if (!util.isArray(val)) return successAdapter.call(promise, val, nodeback);
     var ret = tryCatch(nodeback).apply(promise._boundTo, [null].concat(val));
     if (ret === errorObj) {
-        async.throwLater(ret.e);
+        var e = errorObj.e;
+        errorObj.e = null;
+        async.throwLater(e);
     }
 }
 
@@ -23,7 +25,9 @@ function successAdapter(val, nodeback) {
         ? tryCatch(nodeback).call(receiver, null)
         : tryCatch(nodeback).call(receiver, null, val);
     if (ret === errorObj) {
-        async.throwLater(ret.e);
+        var e = errorObj.e;
+        errorObj.e = null;
+        async.throwLater(e);
     }
 }
 function errorAdapter(reason, nodeback) {
@@ -39,7 +43,9 @@ function errorAdapter(reason, nodeback) {
     ASSERT(typeof nodeback == "function");
     var ret = tryCatch(nodeback).call(promise._boundTo, reason);
     if (ret === errorObj) {
-        async.throwLater(ret.e);
+        var e = errorObj.e;
+        errorObj.e = null;
+        async.throwLater(e);
     }
 }
 

--- a/src/progress.js
+++ b/src/progress.js
@@ -32,20 +32,22 @@ Promise.prototype._doProgressWith = function (progression) {
     ASSERT(promise instanceof Promise);
     var ret = tryCatch(handler).call(receiver, progressValue);
     if (ret === errorObj) {
+        var e = errorObj.e;
+        errorObj.e = null;
         //2.4 if the onProgress callback throws an exception
         //with a name property equal to 'StopProgressPropagation',
         //then the error is silenced.
-        if (ret.e != null &&
-            ret.e.name !== "StopProgressPropagation") {
+        if (e != null &&
+            e.name !== "StopProgressPropagation") {
             //2.3 Unless the onProgress callback throws an exception
             //with a name property equal to
             //'StopProgressPropagation',
             // the result of the function is used as the progress
             //value to propagate.
-            var trace = util.canAttachTrace(ret.e)
-                ? ret.e : new Error(util.toString(ret.e));
+            var trace = util.canAttachTrace(e)
+                ? e : new Error(util.toString(e));
             promise._attachExtraTrace(trace);
-            promise._progress(ret.e);
+            promise._progress(e);
         }
     //2.2 The onProgress callback may return a promise.
     } else if (ret instanceof Promise) {

--- a/src/promisify.js
+++ b/src/promisify.js
@@ -182,7 +182,9 @@ function(callback, receiver, originalName, fn) {
                 [CodeForSwitchCase]                                          \n\
             }                                                                \n\
             if (ret === errorObj) {                                          \n\
-                promise._rejectCallback(maybeWrapAsError(ret.e), true, true);\n\
+                var e = errorObj.e;                                          \n\
+                errorObj.e = null;                                           \n\
+                promise._rejectCallback(maybeWrapAsError(e), true, true);    \n\
             }                                                                \n\
             return promise;                                                  \n\
         };                                                                   \n\

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -129,7 +129,11 @@ ReductionPromiseArray.prototype._promiseFulfilled = function (value, index) {
         }
         this._promise._popContext();
 
-        if (ret === errorObj) return this._reject(ret.e);
+        if (ret === errorObj) {
+            var e = errorObj.e;
+            errorObj.e = null;
+            return this._reject(e);
+        }
 
         var maybePromise = tryConvertToPromise(ret, this._promise);
         if (maybePromise instanceof Promise) {

--- a/src/thenables.js
+++ b/src/thenables.js
@@ -24,8 +24,10 @@ function tryConvertToPromise(obj, context) {
         }
         var then = util.tryCatch(getThen)(obj);
         if (then === errorObj) {
+            var e = errorObj.e;
+            errorObj.e = null;
             if (context) context._pushContext();
-            var ret = Promise.reject(then.e);
+            var ret = Promise.reject(e);
             if (context) context._popContext();
             return ret;
         } else if (typeof then === "function") {
@@ -58,7 +60,9 @@ function doThenable(x, then, context) {
                                         progressFromThenable);
     synchronous = false;
     if (promise && result === errorObj) {
-        promise._rejectCallback(result.e, true, true);
+        var e = errorObj.e;
+        errorObj.e = null;
+        promise._rejectCallback(e, true, true);
         promise = null;
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -25,7 +25,9 @@ var errorObj = {e: {}};
 var tryCatchTarget;
 function tryCatcher() {
     try {
-        return tryCatchTarget.apply(this, arguments);
+        var target = tryCatchTarget;
+        tryCatchTarget = null;
+        return target.apply(this, arguments);
     } catch (e) {
         errorObj.e = e;
         return errorObj;


### PR DESCRIPTION
In applications that make sporadic use of bluebird a callback might be retained in `tryCatchTarget`. This leads to all objects associated with that promise/callback chain being retained. Avoid this by resetting `tryCatchTarget` before calling it.

This is also the case for objects in `errorObj` and `NEXT_FILTER`. As errors might only occur occasionally this might retain objects associated with errors.

![Retention in chrome heap profiler](https://drive.google.com/uc?id=0BxK6NZVffAKweldNVjZUSkZmWG8)