### PR TITLE
Warn when Promise.resolve is passed a function

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -174,6 +174,11 @@ Promise.cast = function (obj) {
         ret._setFulfilled();
         ret._rejectionHandler0 = obj;
     }
+    if(debug.warnings() && typeof obj === "function"){
+        ret._warn(".resolve() was passed a function and not a value. " +
+        "Note that this does not convert APIs to use promises. " + 
+        "See http://bluebirdjs.com/docs/api/promisification.html");
+    }
     return ret;
 };
 

--- a/src/promise.js
+++ b/src/promise.js
@@ -174,10 +174,12 @@ Promise.cast = function (obj) {
         ret._setFulfilled();
         ret._rejectionHandler0 = obj;
     }
-    if(debug.warnings() && typeof obj === "function"){
-        ret._warn(".resolve() was passed a function and not a value. " +
+    if(typeof obj === "function" && debug.warnings()) {
+        ret._warn(
+        ".resolve() was passed a function and not a value. " +
         "Note that this does not convert APIs to use promises. " + 
-        "See http://bluebirdjs.com/docs/api/promisification.html");
+        "See http://bluebirdjs.com/docs/api/promisification.html"
+        );
     }
     return ret;
 };


### PR DESCRIPTION
Warn when users pass `Promise.resolve` a callback returning function and expect it to return a promise. 

This was asked in Stack Overflow at least a dozen times (most recent http://stackoverflow.com/questions/30565855/can-bluebird-promise-work-with-redis-in-node-js). Apparently it's also an issue with new developers in code bases.