### PR TITLE
Prevent Electron-based applications from being detected as node.js

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -293,7 +293,8 @@ var ret = {
     hasDevTools: typeof chrome !== "undefined" && chrome &&
                  typeof chrome.loadTimes === "function",
     isNode: typeof process !== "undefined" &&
-        classString(process).toLowerCase() === "[object process]" && (!process.type || process.type === 'browser'),
+        classString(process).toLowerCase() === "[object process]" &&
+        (!process.type || process.type === "browser"),
     isNativeFunctionMethod: isNativeFunctionMethod
 };
 ret.isRecentNode = ret.isNode && (function() {

--- a/src/util.js
+++ b/src/util.js
@@ -293,7 +293,7 @@ var ret = {
     hasDevTools: typeof chrome !== "undefined" && chrome &&
                  typeof chrome.loadTimes === "function",
     isNode: typeof process !== "undefined" &&
-        classString(process).toLowerCase() === "[object process]",
+        classString(process).toLowerCase() === "[object process]" && (!process.type || process.type === 'browser'),
     isNativeFunctionMethod: isNativeFunctionMethod
 };
 ret.isRecentNode = ret.isNode && (function() {


### PR DESCRIPTION
If we are in an [Electron-based application](http://electron.atom.io), the browser process should have node.js Zen Nature, while other ones (renderer) should be treated as if we are in a browser
