### PR TITLE
should preserve domain of the callback function

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -217,19 +217,6 @@ Promise.prototype._then = function (
         if (!haveInternalData) ret._setIsMigrated();
     }
 
-    // preserve domain context if any
-    if (process.domain) {
-        if (didFulfill) {
-            didFulfill = process.domain.bind(didFulfill);
-        }
-        if (didReject) {
-            didReject = process.domain.bind(didReject);
-        }
-        if (didProgress) {
-            didProgress = process.domain.bind(didProgress);
-        }
-    }
-
     var callbackIndex =
         target._addCallbacks(didFulfill, didReject, didProgress, ret, receiver);
 

--- a/src/promise.js
+++ b/src/promise.js
@@ -217,6 +217,19 @@ Promise.prototype._then = function (
         if (!haveInternalData) ret._setIsMigrated();
     }
 
+    // preserve domain context if any
+    if (process.domain) {
+        if (didFulfill) {
+            didFulfill = process.domain.bind(didFulfill);
+        }
+        if (didReject) {
+            didReject = process.domain.bind(didReject);
+        }
+        if (didProgress) {
+            didProgress = process.domain.bind(didProgress);
+        }
+    }
+
     var callbackIndex =
         target._addCallbacks(didFulfill, didReject, didProgress, ret, receiver);
 

--- a/test/mocha/domain.js
+++ b/test/mocha/domain.js
@@ -110,7 +110,7 @@ if (testUtils.isRecentNode) {
                 assert.equal(false, !!process.domain);
                 assert.equal('foo', this.ref);
                 done();
-            });
+            }).catch(done);
 
             deferred.resolve("ok");
 
@@ -132,10 +132,14 @@ if (testUtils.isRecentNode) {
                 assert.equal('foo', this.ref);
                 done();
             }).nodeify(function shouldKeepThisAndEmptyDomain() {
-                assert.equal(false, !!process.domain);
-                assert.equal('foo', this.ref);
-                done();
-            });
+                try {
+                    assert.equal(false, !!process.domain);
+                    assert.equal('foo', this.ref);
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            }).catch(done);
 
             deferred.resolve("ok");
 
@@ -158,10 +162,12 @@ if (testUtils.isRecentNode) {
                 assert.equal('foo', this.ref);
                 done();
             }).nodeify(function shouldKeepThisAndEmptyDomain() {
-                assert.equal(false, !!process.domain);
-                assert.equal('foo', this.ref);
-                done();
-            });
+                try {
+                    assert.equal(false, !!process.domain);
+                    assert.equal('foo', this.ref);
+                    done();
+                } catch (err) { done(err); }
+            }).catch(done);
 
             var domain = Domain.create();
             domain.run(function () {
@@ -174,10 +180,12 @@ if (testUtils.isRecentNode) {
                     assert.equal(domain, process.domain);
                     assert.equal('bar', this.ref);
                     done();
-                }).nodeify(function shouldKeepThisAndDomain() {
-                    assert.equal(domain, process.domain);
-                    assert.equal('bar', this.ref);
-                    done();
+                }).catch(done).nodeify(function shouldKeepThisAndDomain() {
+                    try {
+                        assert.equal(domain, process.domain);
+                        assert.equal('bar', this.ref);
+                        done();
+                    } catch (err) { done(err); }
                 });
             });
 
@@ -200,11 +208,14 @@ if (testUtils.isRecentNode) {
                 assert.equal(false, !!process.domain);
                 assert.equal('foo', this.ref);
                 done();
-            }).nodeify(function shouldKeepThisAndEmptyDomain() {
-                assert.equal(false, !!process.domain);
-                assert.equal('foo', this.ref);
-                done();
-            });
+            }).catch(done).nodeify(function shouldKeepThisAndEmptyDomain() {
+                try {
+                    assert.equal(false, !!process.domain);
+                    assert.equal('foo', this.ref);
+                    done();
+                }
+                catch (err) { done(err); }
+            }, done);
 
             var domain1 = Domain.create();
             domain1.run(function () {
@@ -217,11 +228,14 @@ if (testUtils.isRecentNode) {
                     assert.equal(domain1, process.domain);
                     assert.equal('bar', this.ref);
                     done();
-                }).nodeify(function shouldKeepThisAndDomain() {
-                    assert.equal(domain1, process.domain);
-                    assert.equal('bar', this.ref);
-                    done();
-                });
+                }).catch(done).nodeify(function shouldKeepThisAndDomain() {
+                    try {
+                        assert.equal(domain1, process.domain);
+                        assert.equal('bar', this.ref);
+                        done();
+                    }
+                    catch (err) { done(err); }
+                }, done);
             });
 
             var domain2 = Domain.create();
@@ -235,10 +249,13 @@ if (testUtils.isRecentNode) {
                     assert.equal(domain2, process.domain);
                     assert.equal('qaz', this.ref);
                     done();
-                }).nodeify(function shouldKeepThisAndDomain() {
-                    assert.equal(domain2, process.domain);
-                    assert.equal('qaz', this.ref);
-                    done();
+                }).catch(done).nodeify(function shouldKeepThisAndDomain() {
+                    try {
+                        assert.equal(domain2, process.domain);
+                        assert.equal('qaz', this.ref);
+                        done();
+                    }
+                    catch (err) { done(err); }
                 });
             });
 
@@ -259,10 +276,13 @@ if (testUtils.isRecentNode) {
                 assert.equal(false, !!process.domain);
                 assert.equal('foo', this.ref);
                 done();
-            }).nodeify(function shouldKeepThisAndEmptyDomain() {
-                assert.equal(false, !!process.domain);
-                assert.equal('foo', this.ref);
-                done();
+            }).catch(done).nodeify(function shouldKeepThisAndEmptyDomain() {
+                try {
+                    assert.equal(false, !!process.domain);
+                    assert.equal('foo', this.ref);
+                    done();
+                }
+                catch (err) { done(err); }
             });
 
             var domain = Domain.create();
@@ -273,18 +293,21 @@ if (testUtils.isRecentNode) {
                     assert.equal(true, !!process.domain);
                     assert.equal('bar', this.ref);
                     done();
-                }).nodeify(function shouldKeepThisAndDomain() {
-                    assert.equal(true, !!process.domain);
-                    assert.equal('bar', this.ref);
-                    done();
-                });
+                }).catch(done).nodeify(function shouldKeepThisAndDomain(err) {
+                    try {
+                        assert.equal(true, !!process.domain);
+                        assert.equal('bar', this.ref);
+                        done();
+                    }
+                    catch (err) { done(err); }
+                }).catch(done);
             });
 
             deferred.reject('bad');
 
         });
 
-        it('should preserve corresponding state of domain, complex', function(done) {
+        it('should preserve corresponding state of domain in reject, complex', function(done) {
 
             done = createGroupDone(6, done);
 
@@ -296,10 +319,13 @@ if (testUtils.isRecentNode) {
                 assert.equal(false, !!process.domain);
                 assert.equal('foo', this.ref);
                 done();
-            }).nodeify(function shouldKeepThisAndEmptyDomain() {
-                assert.equal(false, !!process.domain);
-                assert.equal('foo', this.ref);
-                done();
+            }).catch(done).nodeify(function shouldKeepThisAndEmptyDomain() {
+                try {
+                    assert.equal(false, !!process.domain);
+                    assert.equal('foo', this.ref);
+                    done();
+                }
+                catch (err) { done(err); }
             });
 
             var domain1 = Domain.create();
@@ -310,10 +336,13 @@ if (testUtils.isRecentNode) {
                     assert.equal(domain1, process.domain);
                     assert.equal('bar', this.ref);
                     done();
-                }).nodeify(function shouldKeepThisAndDomain() {
-                    assert.equal(domain1, process.domain);
-                    assert.equal('bar', this.ref);
-                    done();
+                }).catch(done).nodeify(function shouldKeepThisAndDomain() {
+                    try {
+                        assert.equal(domain1, process.domain);
+                        assert.equal('bar', this.ref);
+                        done();
+                    }
+                    catch (err) { done(err); }
                 });
             });
 
@@ -325,10 +354,13 @@ if (testUtils.isRecentNode) {
                     assert.equal(domain2, process.domain);
                     assert.equal('qaz', this.ref);
                     done();
-                }).nodeify(function shouldKeepThisAndDomain() {
-                    assert.equal(domain2, process.domain);
-                    assert.equal('qaz', this.ref);
-                    done();
+                }).catch(done).nodeify(function shouldKeepThisAndDomain() {
+                    try {
+                        assert.equal(domain2, process.domain);
+                        assert.equal('qaz', this.ref);
+                        done();
+                    }
+                    catch (err) { done(err); }
                 });
             });
 

--- a/test/mocha/domain.js
+++ b/test/mocha/domain.js
@@ -97,13 +97,18 @@ if (testUtils.isRecentNode) {
             }
         });
 
-        it("should preserve empty domain", function(done) {
+        it("should preserve empty domain and this function", function(done) {
 
             var deferred = new Promise.defer();
             var p = deferred.promise;
 
             p.then(function shouldBeEmpty() {
                 assert.equal(false, !!process.domain);
+            }).bind({
+                ref: 'foo'
+            }).then(function shouldKeepThisAndEmptyDomain() {
+                assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
                 done();
             });
 
@@ -112,7 +117,7 @@ if (testUtils.isRecentNode) {
         });
 
         it("should preserve empty domain, nodeify", function(done) {
-            done = createGroupDone(2, done);
+            done = createGroupDone(3, done);
 
             var deferred = new Promise.defer();
             var p = deferred.promise;
@@ -120,8 +125,15 @@ if (testUtils.isRecentNode) {
             p.then(function shouldBeEmpty() {
                 assert.equal(false, !!process.domain);
                 done();
-            }).nodeify(function () {
+            }).bind({
+                ref: 'foo'
+            }).then(function shouldKeepThisAndEmptyDomain() {
                 assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
+                done();
+            }).nodeify(function shouldKeepThisAndEmptyDomain() {
+                assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
                 done();
             });
 
@@ -131,7 +143,7 @@ if (testUtils.isRecentNode) {
 
         it("should preserve corresponding state of domain", function(done) {
 
-            done = createGroupDone(4, done);
+            done = createGroupDone(6, done);
 
             var deferred = new Promise.defer();
             var p = deferred.promise;
@@ -139,8 +151,15 @@ if (testUtils.isRecentNode) {
             p.then(function shouldBeEmpty() {
                 assert.equal(false, !!process.domain);
                 done();
-            }).nodeify(function () {
+            }).bind({
+                ref: 'foo'
+            }).then(function shouldKeepThisAndEmptyDomain() {
                 assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
+                done();
+            }).nodeify(function shouldKeepThisAndEmptyDomain() {
+                assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
                 done();
             });
 
@@ -149,8 +168,15 @@ if (testUtils.isRecentNode) {
                 p.then(function shouldNoBeEmpty() {
                     assert.equal(domain, process.domain);
                     done();
-                }).nodeify(function () {
+                }).bind({
+                    ref: 'bar'
+                }).then(function shouldKeepThisAndDomain() {
                     assert.equal(domain, process.domain);
+                    assert.equal('bar', this.ref);
+                    done();
+                }).nodeify(function shouldKeepThisAndDomain() {
+                    assert.equal(domain, process.domain);
+                    assert.equal('bar', this.ref);
                     done();
                 });
             });
@@ -161,15 +187,22 @@ if (testUtils.isRecentNode) {
 
         it('should preserve corresponding state of domain, complex', function(done) {
 
-            done = createGroupDone(6, done);
+            done = createGroupDone(9, done);
 
             var deferred = new Promise.defer();
             var p = deferred.promise;
             p.then(function shouldBeEmpty() {
                 assert.equal(false, !!process.domain);
                 done();
-            }).nodeify(function () {
+            }).bind({
+                ref: 'foo'
+            }).then(function shouldKeepThisAndEmptyDomain() {
                 assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
+                done();
+            }).nodeify(function shouldKeepThisAndEmptyDomain() {
+                assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
                 done();
             });
 
@@ -178,8 +211,15 @@ if (testUtils.isRecentNode) {
                 p.then(function shouldNoBeEmpty() {
                     assert.equal(domain1, process.domain);
                     done();
-                }).nodeify(function () {
+                }).bind({
+                    ref: 'bar'
+                }).then(function shouldKeepThisAndDomain() {
                     assert.equal(domain1, process.domain);
+                    assert.equal('bar', this.ref);
+                    done();
+                }).nodeify(function shouldKeepThisAndDomain() {
+                    assert.equal(domain1, process.domain);
+                    assert.equal('bar', this.ref);
                     done();
                 });
             });
@@ -189,8 +229,15 @@ if (testUtils.isRecentNode) {
                 p.then(function shouldNoBeEmpty() {
                     assert.equal(domain2, process.domain);
                     done();
-                }).nodeify(function () {
+                }).bind({
+                    ref: 'qaz'
+                }).then(function shouldKeepThisAndDomain() {
                     assert.equal(domain2, process.domain);
+                    assert.equal('qaz', this.ref);
+                    done();
+                }).nodeify(function shouldKeepThisAndDomain() {
+                    assert.equal(domain2, process.domain);
+                    assert.equal('qaz', this.ref);
                     done();
                 });
             });
@@ -206,21 +253,29 @@ if (testUtils.isRecentNode) {
             var deferred = new Promise.defer();
             var p = deferred.promise;
 
-            p.catch(function shouldBeEmpty() {
+            p.bind({
+                ref: 'foo'
+            }).catch(function shouldKeepThisAndEmptyDomain() {
                 assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
                 done();
-            }).nodeify(function () {
+            }).nodeify(function shouldKeepThisAndEmptyDomain() {
                 assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
                 done();
             });
 
             var domain = Domain.create();
             domain.run(function () {
-                p.catch(function shouldNoBeEmpty() {
+                p.bind({
+                    ref: 'bar'
+                }).catch(function shouldNoBeEmpty() {
                     assert.equal(true, !!process.domain);
+                    assert.equal('bar', this.ref);
                     done();
-                }).nodeify(function () {
+                }).nodeify(function shouldKeepThisAndDomain() {
                     assert.equal(true, !!process.domain);
+                    assert.equal('bar', this.ref);
                     done();
                 });
             });
@@ -235,32 +290,44 @@ if (testUtils.isRecentNode) {
 
             var deferred = new Promise.defer();
             var p = deferred.promise;
-            p.catch(function shouldBeEmpty() {
+            p.bind({
+                ref: 'foo'
+            }).catch(function shouldBeEmpty() {
                 assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
                 done();
-            }).nodeify(function () {
+            }).nodeify(function shouldKeepThisAndEmptyDomain() {
                 assert.equal(false, !!process.domain);
+                assert.equal('foo', this.ref);
                 done();
             });
 
             var domain1 = Domain.create();
             domain1.run(function () {
-                p.catch(function shouldNoBeEmpty() {
+                p.bind({
+                    ref: 'bar'
+                }).catch(function shouldNoBeEmpty() {
                     assert.equal(domain1, process.domain);
+                    assert.equal('bar', this.ref);
                     done();
-                }).nodeify(function () {
+                }).nodeify(function shouldKeepThisAndDomain() {
                     assert.equal(domain1, process.domain);
+                    assert.equal('bar', this.ref);
                     done();
                 });
             });
 
             var domain2 = Domain.create();
             domain2.run(function () {
-                p.catch(function shouldNoBeEmpty() {
+                p.bind({
+                    ref: 'qaz'
+                }).catch(function shouldNoBeEmpty() {
                     assert.equal(domain2, process.domain);
+                    assert.equal('qaz', this.ref);
                     done();
-                }).nodeify(function () {
+                }).nodeify(function shouldKeepThisAndDomain() {
                     assert.equal(domain2, process.domain);
+                    assert.equal('qaz', this.ref);
                     done();
                 });
             });


### PR DESCRIPTION
currently, due to sharing of the promise, the caller that does the
resolve/reject passes its domain to other callbacks causing unexpected
behavior.