### PR TITLE
Remove `readmeFilename` from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "uglify-js": "~2.4.16",
     "kefir": "^2.4.1"
   },
-  "readmeFilename": "README.md",
   "main": "./js/main/bluebird.js",
   "browser": "./js/browser/bluebird.js",
   "files": [


### PR DESCRIPTION
Hey,

As per https://github.com/npm/npm/issues/3573#issuecomment-19550501, `readmeFilename` is not official and was droped.
It cannot be ignored by `npm` so it will still be bundled.