### PR TITLE
LICENSE can't be ignored by npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "js/browser",
     "js/main",
     "js/zalgo",
-    "LICENSE",
     "zalgo.js"
   ]
 }


### PR DESCRIPTION
Hey again,

Small cleanup, `LICENSE` does not need to be specified in `files`: https://github.com/npm/npm/blob/master/node_modules/fstream-npm/fstream-npm.js#L91-L124