### PR TITLE
Fix #708 Promise.map concurrency execuition order issue

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -104,7 +104,7 @@ MappingPromiseArray.prototype._drainQueue = function () {
     var values = this._values;
     while (queue.length > 0 && this._inFlight < limit) {
         if (this._isResolved()) return;
-        var index = queue.pop();
+        var index = queue.shift();
         this._promiseFulfilled(values[index], index);
     }
 };

--- a/test/mocha/map.js
+++ b/test/mocha/map.js
@@ -321,10 +321,10 @@ describe("Promise.map-test with concurrency", function () {
             assert.deepEqual(b, [0, 1, 2, 3, 4]);
             lates.forEach(resolve);
         }).delay(1).then(function() {
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6 ]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
             lates.forEach(resolve);
         }).thenReturn(ret1).then(function() {
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6, 5]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         });
         return Promise.all([ret1, ret2]);
     });


### PR DESCRIPTION
See #708. If this isn't acceptable can someone explain why it was implemented the original way?