### PR TITLE
PR for 762

### DIFF
--- a/API.md
+++ b/API.md
@@ -50,7 +50,7 @@
         - [Option: `spread`](#option-spread)
 - [Timers](#timers)
     - [`.delay(int ms)`](#delayint-ms---promise)
-    - [`.timeout(int ms [, String message])`](#timeoutint-ms--string-message---promise)
+    - [`.timeout(int ms [, String|Error message])`](#timeoutint-ms--stringerror-message---promise)
         - [`Promise.delay([dynamic value], int ms)`](#promisedelaydynamic-value-int-ms---promise)
 - [Cancellation](#cancellation)
     - [`.cancellable()`](#cancellable---promise)
@@ -1920,11 +1920,11 @@ Same as calling [`Promise.delay(this, ms)`](#promisedelaydynamic-value-int-ms---
 
 <hr>
 
-#####`.timeout(int ms [, String message])` -> `Promise`
+#####`.timeout(int ms [, String|Error message])` -> `Promise`
 
-Returns a [`cancellable`](#cancellable---promise) promise that will be fulfilled with this promise's fulfillment value or rejection reason. However, if this promise is not fulfilled or rejected within `ms` milliseconds, the returned promise is cancelled with a [`TimeoutError`](#timeouterror) as the cancellation reason.
+Returns a [`cancellable`](#cancellable---promise) promise that will be fulfilled with this promise's fulfillment value or rejection reason. However, if this promise is not fulfilled or rejected within `ms` milliseconds, the returned promise is cancelled with a [`TimeoutError`](#timeouterror) as the cancellation reason or an `Error` if one is passed in instead of a string.
 
-You may specify a custom error message with the `message` parameter.
+You may specify a custom error message with the `message` parameter, or you can pass your own `Error` to reject with instead of a [`TimeoutError`](#timeouterror), subclassing [`TimeoutError`](#timeouterror) for that matter is recommended.
 
 The example function `fetchContent` doesn't leave the ongoing http request in the background in case the request cancelled from outside, either manually or through a timeout.
 

--- a/src/timers.js
+++ b/src/timers.js
@@ -8,7 +8,7 @@ var afterTimeout = function (promise, message) {
     if (!promise.isPending()) return;
     
     var err;
-    if(!util.isPrimitive(message) && (message instanceof Error)){
+    if(!util.isPrimitive(message) && (message instanceof Error)) {
         err = message;
     } else {
         if (typeof message !== "string") {

--- a/src/timers.js
+++ b/src/timers.js
@@ -8,7 +8,7 @@ var afterTimeout = function (promise, message) {
     if (!promise.isPending()) return;
     
     var err;
-    if(!isPrimitive(message) && (message instanceof Error)){
+    if(!util.isPrimitive(message) && (message instanceof Error)){
         err = message;
     } else {
         if (typeof message !== "string") {

--- a/src/timers.js
+++ b/src/timers.js
@@ -6,10 +6,16 @@ var TimeoutError = Promise.TimeoutError;
 var afterTimeout = function (promise, message) {
     //Don't waste time concatting strings or creating stack traces
     if (!promise.isPending()) return;
-    if (typeof message !== "string") {
-        message = TIMEOUT_ERROR;
+    
+    var err;
+    if(!isPrimitive(message) && (message instanceof Error)){
+        err = message;
+    } else {
+        if (typeof message !== "string") {
+            message = TIMEOUT_ERROR;
+        }
+        err = new TimeoutError(message);
     }
-    var err = new TimeoutError(message);
     util.markAsOriginatingFromRejection(err);
     promise._attachExtraTrace(err);
     promise._cancel(err);

--- a/test/mocha/timers.js
+++ b/test/mocha/timers.js
@@ -76,6 +76,15 @@ describe("timeout", function () {
         });
     });
 
+    it("should reject with a custom error if an error was provided as a parameter", function() {
+        var err = Error("Testing Errors")
+        return Promise.delay(1)
+        .timeout(10, err)
+        .caught(function(e){
+            assert(e === err);
+        });
+    });
+    
     it("should propagate the timeout error to cancellable parents", function() {
         function doExpensiveOp() {
             return new Promise(function() {


### PR DESCRIPTION
Allow `.timeout` to take an error instance in 2.x instead of a string as an argument.