### PR TITLE
Implement thru method

### DIFF
--- a/API.md
+++ b/API.md
@@ -62,6 +62,7 @@
     - [`Promise.coroutine.addYieldHandler(function handler)`](#promisecoroutineaddyieldhandlerfunction-handler---void)
 - [Utility](#utility)
     - [`.tap(Function handler)`](#tapfunction-handler---promise)
+    - [`.thru(Function handler)`](#thrufunction-handler---dynamic)
     - [`.call(String propertyName [, dynamic arg...])`](#callstring-propertyname--dynamic-arg---promise)
     - [`.get(String propertyName|int index)`](#getstring-propertynameint-index---promise)
     - [`.return(dynamic value)`](#returndynamic-value---promise)
@@ -2225,6 +2226,32 @@ doSomething()
 ```
 
 *Note: in browsers it is necessary to call `.tap` with `console.log.bind(console)` because console methods can not be called as stand-alone functions.*
+
+<hr>
+
+#####`.thru(Function handler)` -> `Dynamic`
+
+Passes the promise into the handler and returns the result.
+
+Useful if you need to perform a side-effect with the promise itself instead
+of the result. For example, caching or transforming into a stream.
+
+Example, read and log all of the files in a directory:
+
+```js
+var Promise = require("bluebird");
+var fs = Promise.promisifyAll(require("fs"));
+var highland = require("highland");
+
+fs.readdirAsync("./directory")
+    .filter(function(path) {
+        return fs.statAsync(path).call("isFile");
+    })
+    .map(fs.createReadStream)
+    .thru(highland)
+    .flatten()
+    .each(console.log);
+```
 
 <hr>
 

--- a/src/promise.js
+++ b/src/promise.js
@@ -109,6 +109,11 @@ Promise.prototype.reflect = function () {
     return this._then(reflect, reflect, undefined, this, undefined);
 };
 
+Promise.prototype.thru = function(fn) {
+    if (typeof fn !== "function") return apiRejection(NOT_FUNCTION_ERROR);
+    return fn(this);
+};
+
 Promise.prototype.then = function (didFulfill, didReject, didProgress) {
     if (isDebugging() && arguments.length > 0 &&
         typeof didFulfill !== "function" &&

--- a/test/mocha/thru.js
+++ b/test/mocha/thru.js
@@ -1,0 +1,21 @@
+"use strict";
+var assert = require("assert");
+
+describe("thru", function () {
+    specify("passes through promise", function() {
+        var orig = Promise.resolve("test");
+        return orig.thru(function(p) {
+            assert.equal(p, orig);
+        });
+    });
+
+    specify("passes through function return", function() {
+        var orig = Promise.resolve("test");
+        var p = orig.thru(function(p) {
+            return p;
+        });
+        return p.then(function() {
+            assert.equal(p, orig);
+        });
+    });
+});


### PR DESCRIPTION
Implements `Promise.prototype.thru`, a convenience method for chaining. This could be implemented by assigning to a variable or wrapping the promise chain in a method, e.g.,

```js
somethingElse(doSomething()
    .then(...)
    .then(...));
```

But, this allows for cleaner chaining, similar to the [`.thru`](https://lodash.com/docs#thru) method in lodash or the [`.through`](http://highlandjs.org/#through) method in highland.js.

```js
doSomething()
    .then()
    .then()
    .thru(somethingElse);
```