### PR TITLE
Fix "home" link in jekyll default layout

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="{{ "/img/logo.png" | prepend: site.baseurl }}" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>


### PR DESCRIPTION
It was linking to `/bluebird/`, but the new site needs it to link to `/`.