### PR TITLE
Fix link on header logo

### DIFF
--- a/docs/anti-patterns.html
+++ b/docs/anti-patterns.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api-reference.html
+++ b/docs/api-reference.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/aggregateerror.html
+++ b/docs/api/aggregateerror.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/all.html
+++ b/docs/api/all.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/any.html
+++ b/docs/api/any.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/ascallback.html
+++ b/docs/api/ascallback.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/bind.html
+++ b/docs/api/bind.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/built-in-error-types.html
+++ b/docs/api/built-in-error-types.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/call.html
+++ b/docs/api/call.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/cancel.html
+++ b/docs/api/cancel.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/cancellation.html
+++ b/docs/api/cancellation.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/cancellationerror.html
+++ b/docs/api/cancellationerror.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/catch.html
+++ b/docs/api/catch.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/catchreturn.html
+++ b/docs/api/catchreturn.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/catchthrow.html
+++ b/docs/api/catchthrow.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/collections.html
+++ b/docs/api/collections.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/core.html
+++ b/docs/api/core.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/deferred-migration.html
+++ b/docs/api/deferred-migration.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/delay.html
+++ b/docs/api/delay.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/disposer.html
+++ b/docs/api/disposer.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/done.html
+++ b/docs/api/done.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/each.html
+++ b/docs/api/each.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/environment-variables.html
+++ b/docs/api/environment-variables.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/error-management-configuration.html
+++ b/docs/api/error-management-configuration.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/error.html
+++ b/docs/api/error.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/filter.html
+++ b/docs/api/filter.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/finally.html
+++ b/docs/api/finally.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/generators.html
+++ b/docs/api/generators.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/get.html
+++ b/docs/api/get.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/iscancelled.html
+++ b/docs/api/iscancelled.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/isfulfilled.html
+++ b/docs/api/isfulfilled.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/ispending.html
+++ b/docs/api/ispending.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/isrejected.html
+++ b/docs/api/isrejected.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/map.html
+++ b/docs/api/map.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/new-promise.html
+++ b/docs/api/new-promise.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/operationalerror.html
+++ b/docs/api/operationalerror.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/progression-migration.html
+++ b/docs/api/progression-migration.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.all.html
+++ b/docs/api/promise.all.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.any.html
+++ b/docs/api/promise.any.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.bind.html
+++ b/docs/api/promise.bind.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.config.html
+++ b/docs/api/promise.config.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.coroutine.addyieldhandler.html
+++ b/docs/api/promise.coroutine.addyieldhandler.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.coroutine.html
+++ b/docs/api/promise.coroutine.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.delay.html
+++ b/docs/api/promise.delay.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.each.html
+++ b/docs/api/promise.each.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.filter.html
+++ b/docs/api/promise.filter.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.fromcallback.html
+++ b/docs/api/promise.fromcallback.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.join.html
+++ b/docs/api/promise.join.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.longstacktraces.html
+++ b/docs/api/promise.longstacktraces.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.map.html
+++ b/docs/api/promise.map.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.method.html
+++ b/docs/api/promise.method.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.noconflict.html
+++ b/docs/api/promise.noconflict.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.onpossiblyunhandledrejection.html
+++ b/docs/api/promise.onpossiblyunhandledrejection.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.onunhandledrejectionhandled.html
+++ b/docs/api/promise.onunhandledrejectionhandled.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.promisify.html
+++ b/docs/api/promise.promisify.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.promisifyall.html
+++ b/docs/api/promise.promisifyall.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.props.html
+++ b/docs/api/promise.props.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.race.html
+++ b/docs/api/promise.race.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.reduce.html
+++ b/docs/api/promise.reduce.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.reject.html
+++ b/docs/api/promise.reject.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.resolve.html
+++ b/docs/api/promise.resolve.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.setscheduler.html
+++ b/docs/api/promise.setscheduler.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.some.html
+++ b/docs/api/promise.some.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.try.html
+++ b/docs/api/promise.try.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promise.using.html
+++ b/docs/api/promise.using.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promiseinspection.html
+++ b/docs/api/promiseinspection.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/promisification.html
+++ b/docs/api/promisification.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/props.html
+++ b/docs/api/props.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/race.html
+++ b/docs/api/race.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/reason.html
+++ b/docs/api/reason.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/reduce.html
+++ b/docs/api/reduce.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/reflect.html
+++ b/docs/api/reflect.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/resource-management.html
+++ b/docs/api/resource-management.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/return.html
+++ b/docs/api/return.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/some.html
+++ b/docs/api/some.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/spread.html
+++ b/docs/api/spread.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/suppressunhandledrejections.html
+++ b/docs/api/suppressunhandledrejections.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/synchronous-inspection.html
+++ b/docs/api/synchronous-inspection.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/tap.html
+++ b/docs/api/tap.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/then.html
+++ b/docs/api/then.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/throw.html
+++ b/docs/api/throw.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/timeout.html
+++ b/docs/api/timeout.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/timeouterror.html
+++ b/docs/api/timeouterror.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/timers.html
+++ b/docs/api/timers.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/utility.html
+++ b/docs/api/utility.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/api/value.html
+++ b/docs/api/value.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/async-dialogs.html
+++ b/docs/async-dialogs.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/beginners-guide.html
+++ b/docs/beginners-guide.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/coming-from-other-languages.html
+++ b/docs/coming-from-other-languages.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/coming-from-other-libraries.html
+++ b/docs/coming-from-other-libraries.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/contribute.html
+++ b/docs/contribute.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/deprecated-apis.html
+++ b/docs/deprecated-apis.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/deprecated_apis.html
+++ b/docs/deprecated_apis.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/error-explanations.html
+++ b/docs/error-explanations.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/features.html
+++ b/docs/features.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/install.html
+++ b/docs/install.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/new-in-bluebird-3.html
+++ b/docs/new-in-bluebird-3.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/support.html
+++ b/docs/support.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/warning-explanations.html
+++ b/docs/warning-explanations.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/what-about-generators.html
+++ b/docs/what-about-generators.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/why-bluebird.html
+++ b/docs/why-bluebird.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/why-performance.html
+++ b/docs/why-performance.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/why-promises.html
+++ b/docs/why-promises.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>

--- a/docs/working-with-callbacks.html
+++ b/docs/working-with-callbacks.html
@@ -33,7 +33,7 @@
                     <span class="icon-bar"></span>
                 </button>
 
-                <a href="/bluebird" class="title">
+                <a href="/" class="title">
                     <img src="/img/logo.png" class="hidden-xs" />
 
                     <span class="tagline">bluebird</span>


### PR DESCRIPTION
The header logo linked to `/bluebird` which caused a 404. 

This patch links every logo to `/`.