### PR TITLE
Docs: use Promise.fromCallback instead of Promise.defer().callback

### DIFF
--- a/docs/docs/api/promise.coroutine.addyieldhandler.md
+++ b/docs/docs/api/promise.coroutine.addyieldhandler.md
@@ -67,9 +67,9 @@ var fs = require("fs");
 
 Promise.coroutine.addYieldHandler(function(v) {
     if (typeof v === "function") {
-        var def = Promise.defer();
-        try { v(def.callback); } catch(e) { def.reject(e); }
-        return def.promise;
+        return Promise.fromCallback(function(cb) {
+            v(cb);
+        });
     }
 });
 


### PR DESCRIPTION
The docs make use of `defer.callback`, but from running the code and looking at the source code for `Promise.defer` it is apparent that `Promise.defer().callback` is undefined. Instead, use `Promise.fromCallback()`.