### PR TITLE
Include bluebird in bluebirdjs.com

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -119,6 +119,7 @@
     <footer></footer>
     <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/bluebird/{{ site.version }}/bluebird.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Some documentation sites include their own library in the source code so that users can use the debug console as a playground. One example is lodash (https://lodash.com/docs). It makes it a lot easier to quickly test something out. Not a big deal though.