### PR TITLE
Handle promises arrays with properties

### DIFF
--- a/src/promise_array.js
+++ b/src/promise_array.js
@@ -87,7 +87,16 @@ PromiseArray.prototype._init = function init(_, resolveValueIfEmpty) {
 PromiseArray.prototype._iterate = function(values) {
     var len = this.getActualLength(values.length);
     this._length = len;
-    this._values = this.shouldCopyValues() ? new Array(len) : this._values;
+    if (this.shouldCopyValues()) {
+         // Create new array and copy custom properties
+         // getOwnPropertyNames is not used as it appeared in ECMA script 5.1 only
+         this._values = new Array(len);
+         for (var property in values) {
+             if (values.hasOwnProperty(property)) {
+                 this._values[property] = values[property];
+             }
+         }
+    }
     var result = this._promise;
     var isResolved = false;
     var bitField = null;

--- a/src/promise_array.js
+++ b/src/promise_array.js
@@ -88,8 +88,6 @@ PromiseArray.prototype._iterate = function(values) {
     var len = this.getActualLength(values.length);
     this._length = len;
     if (this.shouldCopyValues()) {
-         // Create new array and copy custom properties
-         // getOwnPropertyNames is not used as it appeared in ECMA script 5.1 only
          this._values = new Array(len);
          for (var property in values) {
              if (values.hasOwnProperty(property)) {


### PR DESCRIPTION
In case when variable "values" contains array of promises with properties (http://stackoverflow.com/questions/9952126/add-property-to-javascript-array) creation of new array causes the resolved array not to have the properties of original array (except length).
Proposed solution is copying the custom properties from original array to the resolved array. This solution involves minimal performance overhead (http://jsperf.com/cloning-an-object). I do not use getOwnPropertyNames as it appeared in ECMA script 5.1 only.