### PR TITLE
Fixed build on windows

### DIFF
--- a/tools/utils.js
+++ b/tools/utils.js
@@ -4,9 +4,8 @@ var path = require("path");
 var spawn = require("cross-spawn");
 Promise.longStackTraces();
 var fs = Promise.promisifyAll(require("fs"));
-var notAscii = /[^\u0019-\u007E]/;
+var notAscii = /[^\u000D\u0019-\u007E]/;
 var Table = require('cli-table');
-var os = require('os');
 
 function noStackError(message) {
     var e = new Error(message);
@@ -16,7 +15,7 @@ function noStackError(message) {
 
 function checkAscii(fileName, contents) {
     if (notAscii.test(contents)) {
-        contents.split(os.EOL).forEach(function(line, i) {
+        contents.split("\n").forEach(function(line, i) {
             if (notAscii.test(line)) {
                 var lineNo = i + 1;
                 var col = line.indexOf(RegExp.lastMatch) + 1;

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -6,6 +6,7 @@ Promise.longStackTraces();
 var fs = Promise.promisifyAll(require("fs"));
 var notAscii = /[^\u0019-\u007E]/;
 var Table = require('cli-table');
+var os = require('os');
 
 function noStackError(message) {
     var e = new Error(message);
@@ -15,7 +16,7 @@ function noStackError(message) {
 
 function checkAscii(fileName, contents) {
     if (notAscii.test(contents)) {
-        contents.split("\n").forEach(function(line, i) {
+        contents.split(os.EOL).forEach(function(line, i) {
             if (notAscii.test(line)) {
                 var lineNo = i + 1;
                 var col = line.indexOf(RegExp.lastMatch) + 1;


### PR DESCRIPTION
"npm install" on windows failed with unhandled rejection error, which was caused by os specific line separator used for parsing source files.