### PR TITLE
Updating Travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,12 @@ language: node_js
 matrix:
   include:
     - node_js: "0.10"
-      env: "NODE_FLAGS='' SCRIPT_FLAGS=''"
     - node_js: "0.12"
-      env: "NODE_FLAGS='' SCRIPT_FLAGS=''"
-    - node_js: "iojs"
-      env: "NODE_FLAGS='' SCRIPT_FLAGS='--saucelabs'"
-    - node_js: "iojs"
-      env: "NODE_FLAGS='' SCRIPT_FLAGS=''"
+    - node_js: "4"
+    - node_js: "5"
   fast_finish: true
-
+env:
+  - "NODE_FLAGS='' SCRIPT_FLAGS=''"  
 before_script:
 - git submodule update --init --recursive
 script: "node $NODE_FLAGS tools/test.js $SCRIPT_FLAGS"


### PR DESCRIPTION
Changes:

* Test only against environments that matter today - NodeJS 0.10, 0.12, 4.x and 5.x
* Set environment in one place, since it is now all the same across each test environment