### PR TITLE
Travis script updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,12 @@ sudo: false
 matrix:
   include:
     - node_js: "0.10"
-      env: "NODE_FLAGS='' SCRIPT_FLAGS=''"
     - node_js: "0.12"
-      env: "NODE_FLAGS='' SCRIPT_FLAGS=''"
-    - node_js: "iojs"
-      env: "NODE_FLAGS='' SCRIPT_FLAGS='--saucelabs'"
-    - node_js: "iojs"
-      env: "NODE_FLAGS='' SCRIPT_FLAGS=''"
+    - node_js: "4"
+    - node_js: "5"
   fast_finish: true
-
+env:
+  - "NODE_FLAGS='' SCRIPT_FLAGS=''"  
 before_script:
 - git submodule update --init --recursive
 script: "node $NODE_FLAGS tools/test.js $SCRIPT_FLAGS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 matrix:
   include:
     - node_js: "0.10"


### PR DESCRIPTION
* Set testing against environments that matter today - NodeJS 0.10, 0.12, 4.x and 5.x
* Moved the same environment settings into their own section
* Added support for the new Travis CI containment mode: `sudo: false`
