### PR TITLE
Document unreachable code purpose

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -201,6 +201,9 @@ function toFastProperties(obj) {
     while (l--) new FakeConstructor();
     ASSERT("%HasFastProperties", true, obj);
     return obj;
+    // Prevent the function from being optimized through dead code elimination
+    // or further optimizations. This code is never reached but even using eval
+    // in unreachable code causes v8 to not optimize functions.
     eval(obj);
 }
 


### PR DESCRIPTION
This is the same PR as #769 but on the current state of the repository because I didn't manage to rebase my previous commit.

Document unreachable code purpose since it's triggering "unreachable code after return statement" warning in Firefox when browserify-ied.

cf. https://bugzilla.mozilla.org/show_bug.cgi?id=1151931
cf. http://stackoverflow.com/questions/24987896/how-does-bluebirds-util-tofastproperties-function-make-an-objects-properties

Note: The text of the comment is a copy of Benjamin Gruenbaum's original comment.
