### PR TITLE
Add padding to the bottom of pages

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -2,6 +2,10 @@ body {
     font-size: 16px;
 }
 
+body > .container {
+    padding-bottom: 50px;
+}
+
 .navbar-bluebird {
     font-family: 'Raleway', sans-serif;
     font-size: 18px;


### PR DESCRIPTION
Makes documentation pages visually a bit more pleasing. I didn't succeed to get jekyll running so didn't actually test this locally.

