### PR TITLE
Add redcarpet and pygments to Gemfile

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem "jekyll"
 gem "jekyll-redirect-from"
 gem "sanitize"
+gem "redcarpet"
+gem "pygments.rb"
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
Oddly, on my Mac OS X system when I run a `bundle install` it does not install **redcarpet** or **pygments**. These are normally installed as dependencies of **jekyll** under the windows platform. This commit fixes the following errors when running `jekyll serve`:

    Configuration file: /Users/suki/source/bluebird/docs/_config.yml
    /Users/suki/source/bluebird/docs/_plugins/plugin.rb:1:in `require': cannot load such file -- redcarpet (LoadError)
            from /Users/suki/source/bluebird/docs/_plugins/plugin.rb:1:in `<top (required)>'

    Configuration file: /Users/suki/source/bluebird/docs/_config.yml
    /Users/suki/source/bluebird/docs/_plugins/plugin.rb:2:in `require': cannot load such file -- pygments (LoadError)
            from /Users/suki/source/bluebird/docs/_plugins/plugin.rb:2:in `<top (required)>'