### PR TITLE
It's not currently possible to disable long stack traces when using Bluebird via webpack or browserify

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -186,7 +186,7 @@ function buildDebug(sources, depsRequireCode, dir) {
     });
 }
 
-function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, npmPackage, license) {
+function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, enableDebug, npmPackage, license) {
     return Promise.join(dir, tmpDir, npmPackage, license, function(dir, tmpDir, npmPackage, license) {
         return Promise.map(sources, function(source) {
             return jobRunner.run(function() {
@@ -229,8 +229,9 @@ function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, npmPackage,
                     src = src + alias;
                     src = src.replace(/\brequire\b/g, "_dereq_");
                     var minWrite, write;
+                    var debugString = enableDebug ? "true" : "false";
                     if (minify) {
-                        var minSrc = src.replace( /__DEBUG__/g, "false" );
+                        var minSrc = src.replace( /__DEBUG__/g, debugString );
                         minSrc = UglifyJS.minify(minSrc, {
                             comments: false,
                             compress: true,
@@ -239,7 +240,7 @@ function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, npmPackage,
                         minSrc  = license + header + minSrc;
                         minWrite = fs.writeFileAsync(minDest, minSrc);
                     }
-                    src = src.replace( /__DEBUG__/g, "true" );
+                    src = src.replace( /__DEBUG__/g, debugString );
                     src = license + header + src;
                     write = fs.writeFileAsync(dest, src);
 
@@ -251,7 +252,8 @@ function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, npmPackage,
                     root: dir,
                     entries: path.join(tmpDir, "bluebird.js"),
                     license: license,
-                    minify: minify
+                    minify: minify,
+                    enableDebug: enableDebug
                 }
             })
         });
@@ -315,7 +317,7 @@ function build(options) {
         if (options.debug)
             debug = buildDebug(results, depsRequireCode, debugDir);
         if (options.browser)
-            browser = buildBrowser(results, browserDir, browserTmpDir, depsRequireCode, options.minify, npmPackage, license);
+            browser = buildBrowser(results, browserDir, browserTmpDir, depsRequireCode, options.minify, options.debug, npmPackage, license);
 
         return Promise.all([release, debug, browser]);
     });


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/petkaantonov/bluebird/issues/897

When using Bluebird with webpack or browserify, the `./js/browser/bluebird.js` file is used, which is currently build with `__DEBUG__` set to `true`.

This has a major performance impact on Bluebird in a production environment.

This PR sets `__DEBUG__` to false by default, except if `build.js` is invoked with `--debug`.

Please let me know if there are any changes you would like me to make.