### PR TITLE
Fix documentation for Promise.using

### DIFF
--- a/docs/docs/api/promise.using.md
+++ b/docs/docs/api/promise.using.md
@@ -26,8 +26,7 @@ Promise.using(
 
 In conjunction with [`.disposer`](.), `using` will make sure that no matter what, the specified disposer will be called when the promise returned by the callback passed to `using` has settled. The disposer is necessary because there is no standard interface in node for disposing resources.
 
-Here is a simple example ` [has been defined] to return a proper undefined))
-
+Here is a simple example (where `getConnection()` has been defined to return a proper Disposer object)
 
 ```js
 using(getConnection(), function(connection) {
@@ -84,7 +83,7 @@ using(readFile("1.txt"), readFile("2.txt"), getConnection(), function(txt1, txt2
 
 <hr>
 
-+You can also pass the resources in an array in the first argument. In this case the handler function will only be called with one rgument that is the array containing the resolved resources in respective positions in the array. Example:
+You can also pass the resources in an array in the first argument. In this case the handler function will only be called with one argument that is the array containing the resolved resources in respective positions in the array. Example:
 
 ```js
 var connectionPromises = [getConnection(), getConnection()];

--- a/docs/docs/api/resource-management.md
+++ b/docs/docs/api/resource-management.md
@@ -32,7 +32,7 @@ reading the file may fail and then of course `.spread` is not called at all and 
 One could solve this by either reading the file first or connecting first, and only proceeding if the first step succeeds. However,
 this would lose a lot of the benefits of using asynchronity and we might almost as well go back to using simple synchronous code.
 
-We can do better, retaining concurrency and not leaking resources, by using undefined:
+We can do better, retaining concurrency and not leaking resources, by using `.using`:
 
 ```js
 var using = Promise.using;


### PR DESCRIPTION
Some of the docs involving `Promise.using` were slightly mangled when migrating documentation from 2.x. This fixes #874.