### PR TITLE
Foreign thenables with internal data keeps resolved value.

### DIFF
--- a/src/thenables.js
+++ b/src/thenables.js
@@ -71,12 +71,14 @@ function doThenable(x, then, context) {
         if (!promise) return;
         promise._resolveCallback(value);
         promise = null;
+        return value;
     }
 
     function reject(reason) {
         if (!promise) return;
         promise._rejectCallback(reason, synchronous, true);
         promise = null;
+        return reason;
     }
     return ret;
 }

--- a/test/mocha/promise_array.js
+++ b/test/mocha/promise_array.js
@@ -175,4 +175,18 @@ describe("Promise.all-test", function () {
         });
     });
 
+    specify("should keep resolved value for foreign thenables with internal data", function() {
+        var foreign = {
+            _v: 2,
+            then: function (f) {
+                this._v = f(this._v);
+                return this._v;
+            }
+        };
+        return Promise.all([foreign, foreign]).then(
+            function (results) {
+                assert.equal(results[0], results[1]);
+            });
+    });
+
 });


### PR DESCRIPTION
This patch makes foreign thenables, with an internal data representation, keep their resolved values when passing through methods like `Promise.all`

Example of thenable object with internal data representation:

    var thenable = {
        _v: 2,
        then: function (f) {
            this._v = f(v);
            return this;
        }
    };

such thenables allow for chained `then` methods that keep transformations from previously called `then` methods, however, if this thenable is passed to `Promise.all` the resolved value is lost because the resolver function from `src/thenables.js` does not return the resolved value again.