### PR TITLE
Fix links to explicit construction anti-pattern.

### DIFF
--- a/docs/docs/anti-patterns.md
+++ b/docs/docs/anti-patterns.md
@@ -6,7 +6,7 @@ title: Anti-patterns
 This page will contain common promise anti-patterns that are exercised in the wild.
 
 
-- [The explicit construction anti-pattern](#the-deferred-anti-pattern)
+- [The explicit construction anti-pattern](#the-explicit-construction-anti-pattern)
 - [The `.then(success, fail)` anti-pattern](#the-thensuccess-fail-anti-pattern)
 
 ##The Explicit Construction Anti-Pattern

--- a/docs/docs/api/new-promise.md
+++ b/docs/docs/api/new-promise.md
@@ -16,7 +16,7 @@ new Promise(function(function resolve, function reject) resolver) -> Promise
 
 Create a new promise. The passed in function will receive functions `resolve` and `reject` as its arguments which can be called to seal the fate of the created promise.
 
-*Note: See [explicit construction anti-pattern]({{ "/docs/anti-patterns.html#explicit-construction-anti-pattern" | prepend: site.baseurl }}) before creating promises yourself*
+*Note: See [explicit construction anti-pattern]({{ "/docs/anti-patterns.html#the-explicit-construction-anti-pattern" | prepend: site.baseurl }}) before creating promises yourself*
 
 Example:
 


### PR DESCRIPTION
Supercedes #901. As mentioned there I still think it likely makes sense to consolidate by linking to the website from https://github.com/petkaantonov/bluebird/wiki/Promise-anti-patterns instead of duplicating the content there.