### PR TITLE
Add longStackTraces to API Reference

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -76,6 +76,7 @@ redirect_from: "/docs/api/index.html"
     - [.reflect](api/reflect.html)
     - [Promise.noConflict](api/promise.noconflict.html)
     - [Promise.setScheduler](api/promise.setscheduler.html)
+    - [Promise.longStackTraces](api/promise.longstacktraces.html)
 - [Built-in error types](api/built-in-error-types.html)
     - [OperationalError](api/operationalerror.html)
     - [TimeoutError](api/timeouterror.html)


### PR DESCRIPTION
I found `Promise.longStackTraces` using Google but noticed it wasn't on the API Reference page. I've added it under "Utility" given that's the section that seems to make the most sense.