### PR TITLE
doc: Fix the "global rejection events" links

### DIFF
--- a/docs/docs/api/promise.onpossiblyunhandledrejection.md
+++ b/docs/docs/api/promise.onpossiblyunhandledrejection.md
@@ -14,7 +14,7 @@ Promise.onPossiblyUnhandledRejection(function(any error, Promise promise) handle
 ```
 
 
-*Note: this hook is specific to the bluebird instance its called on, application developers should use [global rejection events](#global-rejection-events)*
+*Note: this hook is specific to the bluebird instance its called on, application developers should use [global rejection events](/docs/api/error-management-configuration.html#global-rejection-events)*
 
 Add `handler` as the handler to call when there is a possibly unhandled rejection. The default handler logs the error stack to stderr or `console.error` in browsers.
 

--- a/docs/docs/api/promise.onunhandledrejectionhandled.md
+++ b/docs/docs/api/promise.onunhandledrejectionhandled.md
@@ -14,7 +14,7 @@ Promise.onUnhandledRejectionHandled(function(Promise promise) handler) -> undefi
 ```
 
 
-*Note: this hook is specific to the bluebird instance its called on, application developers should use [global rejection events](#global-rejection-events)*
+*Note: this hook is specific to the bluebird instance its called on, application developers should use [global rejection events](/docs/api/error-management-configuration.html#global-rejection-events)*
 
 Add `handler` as the handler to call when a rejected promise that was reported as "possibly unhandled rejection" became handled.
 


### PR DESCRIPTION
It appears that the previously-relative "global rejection events" links on the `Promise.onPossiblyUnhandledRejection` and `Promise.onUnhandledRejectionHandled` pages were overlooked when the API documentation was split into separate pages in 94fd4fe6.  This PR fixes the links to point to the correct page.

Best,
Kevin