### PR TITLE
Make var promisification explicit in the docs

### DIFF
--- a/docs/docs/api/promise.promisifyall.md
+++ b/docs/docs/api/promise.promisifyall.md
@@ -28,7 +28,7 @@ Note that the original methods on the object are not overwritten but new methods
 Example:
 
 ```js
-Promise.promisifyAll(require("redis"));
+var redisClient = Promise.promisifyAll(require("redis"));
 
 //Later on, all redis client instances have promise returning functions:
 


### PR DESCRIPTION
The docs imply that `Promise.promisify(<anything>)` will manipulate instances of that object that are already imported. 