### PR TITLE
Fix defined/undefined typo

### DIFF
--- a/docs/docs/api/catch.md
+++ b/docs/docs/api/catch.md
@@ -40,7 +40,7 @@ Example:
 somePromise.then(function() {
     return a.b.c.d();
 }).catch(TypeError, function(e) {
-    //If a is undefined, will end up here because
+    //If it is a TypeError, will end up here because
     //it is a type error to reference property of undefined
 }).catch(ReferenceError, function(e) {
     //Will end up here if a was never declared at all

--- a/docs/docs/api/catch.md
+++ b/docs/docs/api/catch.md
@@ -40,10 +40,10 @@ Example:
 somePromise.then(function() {
     return a.b.c.d();
 }).catch(TypeError, function(e) {
-    //If a is defined, will end up here because
+    //If a is undefined, will end up here because
     //it is a type error to reference property of undefined
 }).catch(ReferenceError, function(e) {
-    //Will end up here if a wasn't defined at all
+    //Will end up here if a was never declared at all
 }).catch(function(e) {
     //Generic catch-the rest, error wasn't TypeError nor
     //ReferenceError


### PR DESCRIPTION
Fix typo and made `ReferenceError` comment more clear.