### PR TITLE
doc: Document when .finally handler returns a promise or throws

### DIFF
--- a/docs/docs/api/finally.md
+++ b/docs/docs/api/finally.md
@@ -57,7 +57,27 @@ function ajaxGetAsync(url) {
 }
 ```
 
-Now the animation is hidden but an exception or the actual return value will automatically skip the finally and propagate to further chainers. This is more in line with the synchronous `finally` keyword.
+Now the animation is hidden but, unless it throws an exception, the function has no effect on the fulfilled or rejected value of the returned promise.  This is similar to how the synchronous `finally` keyword behaves.
+
+If the handler function passed to `.finally` returns a promise, the promise returned by `.finally` will not be settled until the promise returned by the handler is settled.  If the handler fulfills its promise, the returned promise will be fulfilled or rejected with the original value.  If the handler rejects its promise, the returned promise will be rejected with the handler's value.  This is similar to throwing an exception in a synchronous `finally` block, causing the original value or exception to be forgotten.  This delay can be useful if the actions performed by the handler are done asynchronously.  For example:
+
+```js
+function ajaxGetAsync(url) {
+    return new Promise(function (resolve, reject) {
+        var xhr = new XMLHttpRequest;
+        xhr.addEventListener("error", reject);
+        xhr.addEventListener("load", resolve);
+        xhr.open("GET", url);
+        xhr.send(null);
+    }).finally(function() {
+        return Promise.fromCallback(function(callback) {
+            $("#ajax-loader-animation").fadeOut(1000, callback);
+        });
+    });
+}
+```
+
+If the fade out completes successfully, the returned promise will be fulfilled or rejected with the value from `xhr`.  If `.fadeOut` throws an exception or passes an error to the callback, the returned promise will be rejected with the error from `.fadeOut`.
 
 *For compatibility with earlier ECMAScript version, an alias `.lastly` is provided for [`.finally`](.).*
 </markdown></div>


### PR DESCRIPTION
When the handler function passed to `.finally` throws an exception or returns a promise which is later rejected, the promise returned by `.finally` is rejected with the exception or rejected value.

Although this behavior does not appear to be currently documented, it has been in place since at least 0.7.10.  It is also specified in both Ron Buckton's[1] and Domenic Denicola's[2] proposals and present in all of the implementations I checked[3][4][5][6].  So I assume it is safe to document as part of the API.

This PR does just that.

Thanks for considering,
Kevin

1.  https://gist.github.com/rbuckton/66918c8491aa335b003c
2.  https://github.com/domenic/promises-unwrapping/issues/18
3.  https://github.com/cujojs/when/blob/3.7.7/lib/decorators/flow.js#L72
4.  https://github.com/tildeio/rsvp.js/blob/v3.2.1/lib/rsvp/promise.js#L437
5.  https://github.com/matthew-andrews/Promise.prototype.finally/blob/master/finally.js
6.  https://github.com/blakeembrey/promise-finally/blob/master/src/promise-finally.ts