### PR TITLE
Continue coroutine execution of finally blocks when cancelled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/browser/bundle.js
 js/*
 zalgo.js
 coverage/*
+.vscode

--- a/test/mocha/generator.js
+++ b/test/mocha/generator.js
@@ -501,6 +501,7 @@ describe("Cancellation with generators", function() {
                 if (e === Promise.coroutine.returnSentinel) throw e;
                 unreached++;
             } finally {
+                yield Promise.resolve();
                 finalled++;
             }
             unreached++;
@@ -544,6 +545,7 @@ describe("Cancellation with generators", function() {
                 if (e === Promise.coroutine.returnSentinel) throw e;
                 unreached++;
             } finally {
+                yield Promise.resolve();
                 finalled++;
             }
             unreached++;
@@ -596,6 +598,7 @@ describe("Cancellation with generators", function() {
                 if (e === Promise.coroutine.returnSentinel) throw e;
                 unreached++;
             } finally {
+                yield Promise.resolve()
                 finalled++;
             }
             unreached++;
@@ -646,6 +649,7 @@ describe("Cancellation with generators", function() {
                 if (e === Promise.coroutine.returnSentinel) throw e;
                 unreached++;
             } finally {
+                yield Promise.resolve()
                 finalled++;
             }
             unreached++;
@@ -684,6 +688,7 @@ describe("Cancellation with generators", function() {
             try {
                 yield Promise.delay(100);
             } finally {
+                yield Promise.delay(100);
                 finallyBlockCalled = true;
             }
         });
@@ -691,9 +696,9 @@ describe("Cancellation with generators", function() {
         Promise.resolve().then(function() {
             p.cancel();
         });
-        return p.finally(function() {
+        p.finally(function() {
             assert.ok(finallyBlockCalled, "finally block should have been called before finally handler");
             done();
-        });
+        }).catch(done);
     });
 });


### PR DESCRIPTION
This patches coroutines to continue running after cancellation. There is no way to ensure that they're only running their finally blocks unless the generator iterator supports `.return`, so they could be running a catch block instead.

Might need review / improvements, as well as test on Firefox, and a test of long stack traces.

~~edit: WIP, fixing some final bugs.~~ done