### PR TITLE
Update async benchmark

### DIFF
--- a/benchmark/madeup-parallel/callbacks-caolan-async-parallel.js
+++ b/benchmark/madeup-parallel/callbacks-caolan-async-parallel.js
@@ -1,22 +1,13 @@
 require('../lib/fakes');
 var async = require('async');
 
-function fileInsertFor(i, tx) {
-    return function(callback) {
-        FileVersion.insert({index: i})
-            .execWithin(tx, callback);
-    };
-}
-
 module.exports = function upload(stream, idOrPath, tag, done) {
     var queries = new Array(global.parallelQueries);
     var tx = db.begin();
 
-    for( var i = 0, len = queries.length; i < len; ++i ) {
-        queries[i] = fileInsertFor(i, tx);
-    }
-
-    async.parallel(queries, function(err, callback) {
+    async.forEachOf(queries, function(data, i, done) {
+        FileVersion.insert({index: i}).execWithin(tx, done);
+    }, function(err) {
         if (err) {
             tx.rollback();
             done(err);

--- a/benchmark/madeup-parallel/callbacks-suguru03-neo-async-parallel.js
+++ b/benchmark/madeup-parallel/callbacks-suguru03-neo-async-parallel.js
@@ -1,22 +1,13 @@
 require('../lib/fakes');
 var async = require('neo-async');
 
-function fileInsertFor(i, tx) {
-    return function(callback) {
-        FileVersion.insert({index: i})
-            .execWithin(tx, callback);
-    };
-}
-
 module.exports = function upload(stream, idOrPath, tag, done) {
     var queries = new Array(global.parallelQueries);
     var tx = db.begin();
 
-    for( var i = 0, len = queries.length; i < len; ++i ) {
-        queries[i] = fileInsertFor(i, tx);
-    }
-
-    async.parallel(queries, function(err, callback) {
+    async.each(queries, function(data, i, done) {
+        FileVersion.insert({index: i}).execWithin(tx, done);
+    }, function(err) {
         if (err) {
             tx.rollback();
             done(err);


### PR DESCRIPTION
[Async.js](https://github.com/caolan/async#forEachOf) was added `forEachOf` after v1.x.
The function supports parallel execution and getting array index.
Furthermore, the function is faster than `async.parallel`.
Could you check this PR?