### PR TITLE
Fix typo in PromiseInspection API documentation.

### DIFF
--- a/docs/docs/api/promiseinspection.md
+++ b/docs/docs/api/promiseinspection.md
@@ -13,7 +13,7 @@ title: PromiseInspection
 interface PromiseInspection {
     any reason()
     any value()
-    boolean pending()
+    boolean isPending()
     boolean isRejected()
     boolean isFulfilled()
     boolean isCancelled()


### PR DESCRIPTION
`PromiseInspection.pending()` does not exist, should be `PromiseInspection.isPending()`