### PR TITLE
Comparator used by getOptionalRequireCode() should be consistent.

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -67,15 +67,9 @@ var lastLineCode = "                                                         \n\
 
 function getOptionalRequireCode(srcs) {
     return srcs.sort(function(a, b) {
-        var deps = optionalModuleRequireMap[a.sourceFileName];
-        if (deps !== undefined) {
-            if (Array.isArray(deps)) {
-                return 1;
-            } else {
-                return -1;
-            }
-        }
-        return 0;
+        var aHasDeps = Array.isArray(optionalModuleRequireMap[a.sourceFileName]);
+        var bHasDeps = Array.isArray(optionalModuleRequireMap[b.sourceFileName]);
+        return aHasDeps - bHasDeps;
     }).reduce(function(ret, cur, i) {
         if(optionalModuleRequireMap[cur.sourceFileName]) {
             ret += "require('./"+cur.sourceFileName+"')("+ cur.deps.join(", ") +");\n";


### PR DESCRIPTION
getOptionalRequireCode() in build.js may not sort the modules correctly. It uses Array.sort(comparator) to sort them. The idea of the code is to move the modules that have some dependencies towards the end. Unfortunately, the comparator function used for sorting is not consistent. Let's assume that modules D1 and D2 have dependencies and modules N1 and N2 do not have dependencies (listed in optionalModuleRequireMap) then the current comparator returns the following inconsistent values:

comparator(D1, D2) == 1; comparator(D2, D1) === 1;
comparator(N1, N2) == -1; comparator(N2, N1) === -1;

It should be comparator(X,Y) > 0 if and only if comparator(Y,X) < 0 for a consistent comparator.

The resulting order is not defined when an inconsistent comparator is passed to Array.sort(). It is a pure luck that the order is acceptable when this code is executed on the current version of V8. You may not be so lucky when you execute this code on a different JavaScript engine (or even on a different V8 version). In fact, this is how I found this issue. I tried to figure out why the tests of bluebird fail on our JavaScript engine. They failed because each.js module was loaded before reduce.js (because of the inconsistent comparator).

I suggest to replace the comparator by

function(a, b) {
    var aHasDeps = Array.isArray(optionalModuleRequireMap[a.sourceFileName]);
    var bHasDeps = Array.isArray(optionalModuleRequireMap[b.sourceFileName]);
    return aHasDeps - bHasDeps;
}

it follows the idea of the original comparator but it is also consistent.