### PR TITLE
Add documentation of `Promise.coroutine()` `yieldHandler` option

### DIFF
--- a/docs/docs/api/promise.coroutine.addyieldhandler.md
+++ b/docs/docs/api/promise.coroutine.addyieldhandler.md
@@ -96,13 +96,9 @@ Promise.coroutine.addYieldHandler(function(yieldedValue) {
 });
 
 var readFiles = Promise.coroutine(function* (fileNames) {
-   var promises = [];
-
-   fileNames.forEach(function (fileName) {
-      promises.push(fs.readFileAsync(fileName, "utf8"));
+   return yield fileNames.map(function (fileName) {
+      return fs.readFileAsync(fileName, "utf8");
    });
-
-   return yield promises;
 });
 ```
 </markdown></div>

--- a/docs/docs/api/promise.coroutine.addyieldhandler.md
+++ b/docs/docs/api/promise.coroutine.addyieldhandler.md
@@ -101,6 +101,23 @@ var readFiles = Promise.coroutine(function* (fileNames) {
    });
 });
 ```
+
+A custom yield handler can also be used just for a single call to `Promise.coroutine()`:
+
+```js
+var Promise = require("bluebird");
+var fs = Promise.promisifyAll(require("fs"));
+
+var readFiles = Promise.coroutine(function* (fileNames) {
+   return yield fileNames.map(function (fileName) {
+      return fs.readFileAsync(fileName, "utf8");
+   });
+}, {
+   yieldHandler: function(yieldedValue) {
+      if (Array.isArray(yieldedValue)) return Promise.all(yieldedValue);
+   }
+});
+```
 </markdown></div>
 
 <div id="disqus_thread"></div>

--- a/docs/docs/api/promise.coroutine.md
+++ b/docs/docs/api/promise.coroutine.md
@@ -10,7 +10,7 @@ title: Promise.coroutine
 ##Promise.coroutine
 
 ```js
-Promise.coroutine(GeneratorFunction(...arguments) generatorFunction) -> function
+Promise.coroutine(GeneratorFunction(...arguments) generatorFunction, Object options) -> function
 ```
 
 Returns a function that can use `yield` to yield promises. Control is returned back to the generator when the yielded promise settles. This can lead to less verbose code when doing lots of sequential async calls with minimal processing in between. Requires node.js 0.12+, io.js 1.0+ or Google Chrome 40+.
@@ -58,7 +58,7 @@ Doing `Promise.coroutine` is almost like using the C# `async` keyword to mark th
 
 **Tip**
 
-You are able to yield non-promise values by adding your own yield handler using  [`Promise.coroutine.addYieldHandler`](.)
+You are able to yield non-promise values by adding your own yield handler using  [`Promise.coroutine.addYieldHandler`](.) or calling `Promise.coroutine()` with a yield handler function as `options.yieldHandler`.
 </markdown></div>
 
 <div id="disqus_thread"></div>


### PR DESCRIPTION
This PR adds documentation for `Promise.coroutine()` `yieldHandler` option.

It also simplifies one of the other code examples for `Promise.coroutine.addYieldHandler()`.
