### PR TITLE
Fix scheduler not being called when set during queue draining

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -153,8 +153,8 @@ Async.prototype._drainQueue = function(queue) {
 
 Async.prototype._drainQueues = function () {
     ASSERT(this._isTickUsed);
-    this._drainQueue(this._normalQueue);
     this._reset();
+    this._drainQueue(this._normalQueue);
     this._haveDrainedQueues = true;
     this._drainQueue(this._lateQueue);
 };


### PR DESCRIPTION
We had a failing test in our test suite at @remix, which I was able to
track down to the scheduler not being called from async.js, because
_isTickUsed was not being set to false until after draining the queue.

I don't have time now to write a test case for this, so hopefully
someone can figure that out.

It might be helpful to note that we're using a custom scheduler that
uses `setTimeout(fn, 0)`, but where `setTimeout` is mocked by Jasmine so
that we have control over asynchronous operations.