### PR TITLE
Static method to create separate instance of Bluebird

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -74,6 +74,7 @@ redirect_from: "/docs/api/index.html"
     - [.catchReturn](api/catchreturn.html)
     - [.catchThrow](api/catchthrow.html)
     - [.reflect](api/reflect.html)
+    - [Promise.getNewLibraryCopy](api/promise.getnewlibrarycopy.html)
     - [Promise.noConflict](api/promise.noconflict.html)
     - [Promise.setScheduler](api/promise.setscheduler.html)
 - [Built-in error types](api/built-in-error-types.html)

--- a/docs/docs/api/promise.getnewlibrarycopy.md
+++ b/docs/docs/api/promise.getnewlibrarycopy.md
@@ -1,0 +1,64 @@
+---
+layout: api
+id: promise.getnewlibrarycopy
+title: Promise.getNewLibraryCopy
+---
+
+
+[← Back To API Reference](/docs/api-reference.html)
+<div class="api-code-section"><markdown>
+##Promise.getNewLibraryCopy
+
+```js
+Promise.getNewLibraryCopy() -> Object
+```
+
+Returns a new independent copy of the Bluebird library.
+
+This method should be used before you use any of the methods which would otherwise alter the global `Bluebird` object - to avoid polluting global state.
+
+A basic example:
+
+```js
+var Promise = require('bluebird');
+var Promise2 = Promise.getNewLibraryCopy();
+
+Promise2.x = 123;
+
+console.log(Promise2 == Promise); // false
+console.log(Promise2.x); // 123
+console.log(Promise.x); // undefined
+```
+
+`Promise` is independent to `Promise`. Any changes to `Promise2` do not affect the copy of Bluebird returned by `require('bluebird')`.
+
+In practice:
+
+```js
+var Promise = require('bluebird').getNewLibraryCopy();
+
+Promise.coroutine.addYieldHandler( function() { /* */ } ); // alters behavior of `Promise.coroutine()`
+
+// somewhere in another file or module in same app
+var Promise = require('bluebird');
+
+Promise.coroutine(function*() {
+    // this code is unaffected by the yieldHandler defined above
+    // because it was defined on an independent copy of Bluebird
+});
+```
+</markdown></div>
+
+<div id="disqus_thread"></div>
+<script type="text/javascript">
+    var disqus_title = "Promise.getNewLibraryCopy";
+    var disqus_shortname = "bluebirdjs";
+    var disqus_identifier = "disqus-id-promise.getnewlibrarycopy";
+
+    (function() {
+        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
+        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
+        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
+    })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/src/promise.js
+++ b/src/promise.js
@@ -165,6 +165,8 @@ Promise.prototype.error = function (fn) {
     return this.caught(util.originatesFromRejection, fn);
 };
 
+Promise.getNewLibraryCopy = module.exports;
+
 Promise.is = function (val) {
     return val instanceof Promise;
 };

--- a/test/mocha/getNewLibraryCopy.js
+++ b/test/mocha/getNewLibraryCopy.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var assert = require("assert");
+var testUtils = require("./helpers/util.js");
+
+describe("Promise.getNewLibraryCopy", function() {
+    it("should return an independent copy of Bluebird library", function() {
+        var Promise2 = Promise.getNewLibraryCopy();
+        Promise2.x = 123;
+
+        assert.equal(typeof Promise2.prototype.then, "function");
+        assert.notEqual(Promise2, Promise);
+
+        assert.equal(Promise2.x, 123);
+        assert.notEqual(Promise.x, 123);
+    });
+    it("should return copy of Bluebird library with its own getNewLibraryCopy method", function() {
+        var Promise2 = Promise.getNewLibraryCopy();
+        var Promise3 = Promise2.getNewLibraryCopy();
+        Promise3.x = 123;
+
+        assert.equal(typeof Promise3.prototype.then, "function");
+        assert.notEqual(Promise3, Promise);
+        assert.notEqual(Promise3, Promise2);
+
+        assert.equal(Promise3.x, 123);
+        assert.notEqual(Promise.x, 123);
+        assert.notEqual(Promise2.x, 123);
+    });
+});


### PR DESCRIPTION
This PR is intended as a basis for discussion, rather than "merge me now!"

It feels to me that in many cases module authors should be encouraged to use their own instance of bluebird, rather than the "global" bluebird retrieved by `require('bluebird')`. Here are some examples of where this is the case:

1. Module modifies/shims Bluebird in some way e.g. [cls-bluebird](https://www.npmjs.com/package/cls-bluebird), [bluebird-extra](https://www.npmjs.com/package/bluebird-extra). The host app or other modules may not expect these modifications and it may break them. In the case of [cls-bluebird](https://www.npmjs.com/package/cls-bluebird), it reduces performance of bluebird globally.

2. Bluebird constructor is altered by using static methods/properties of Bluebird constructor. e.g. I am writing a module in which I wish to enable cancellation, but it would be a bad thing if this also enables cancellation in the app that requires my module, as the app author probably wouldn't expect this and it could cause unexpected behaviour.

It is already possible to create a new independent instance of Bluebird with:

```js
require('bluebird/js/release/promise')() // bluebird v3.x
require('bluebird/js/main/promise')() // bluebird v2.x
```

However, this has a few problems:

1. The code is different for v2.x and v3.x
2. It's not accessible if bluebird is injected into a module rather than required directly
3. It may not be possible in the browser (I don't know - I'm server-side only)
4. It's a bit obtuse - hard to encourage people to use it.

This PR adds a static method `.newBluebird()` on the Bluebird constructor, which returns a new independent instance of Bluebird.

```js
var Promise = require('bluebird');
var Promise2 = Promise.newBluebird();
assert.notEqual(Promise, Promise2);
```

There may be better ways to achieve the same thing, and better names for the method than `newBluebird`, but I think in principle it's a good idea for Bluebird to provide this functionality with an easy-to-access method.

What do you think?