### PR TITLE
Replaced Promise.each with Promise.mapSeries

### DIFF
--- a/docs/docs/api/promise.map.md
+++ b/docs/docs/api/promise.map.md
@@ -120,7 +120,7 @@ $ node test.js Infinity
 reading files: 9ms
 ```
 
-The order `map` calls the mapper function on the array elements is not specified, there is no guarantee on the order in which it'll execute the `map`er on the elements. This makes sense because the order of the even with the `{concurrency: 1}`. For order guarantee in sequential execution - see [Promise.each](.).
+The order `map` calls the mapper function on the array elements is not specified, there is no guarantee on the order in which it'll execute the `map`er on the elements. For order guarantee in sequential execution - see [Promise.mapSeries](.).
 </markdown></div>
 
 <div id="disqus_thread"></div>


### PR DESCRIPTION
The serial version of `.map()` isn’t `.each()`, it’s `.mapSeries()` – i.e., if you want to replace a piece of code that doesn’t fail when certain promises in an array fail but you want to maintain the order of promise execution, you should use `.mapSeries()`.

e.g.,

```
Promise.map(inspections, ((inspection) -> return inspection().reflect()), {concurrency: 1})
.then (inspection) ->
	console.log "\nResults:\n"
	inspection
.each (inspection) ->
	if inspection.isFulfilled()
		console.log "  ✅  #{inspection.value()}"
	else
		console.log "  ❌  #{inspection.reason().message}"
```

In the above code, replace .map() with .mapSeries() and you will get the desired effect. Replace it with .each(), as previously suggested and you won’t.

Also removed the broken sentence "This makes sense because the order of the even with the `{concurrency: 1}`." as it doesn’t make grammatical sense and I’m not sure it adds anything to understanding the problem and find the alternative sooner.