### PR TITLE
"register" script to drop in Bluebird as a replacement to native promises via Node's -r flags

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -1,0 +1,2 @@
+"use strict";
+global.Promise = require('./bluebird');


### PR DESCRIPTION
I like using Node's `--require` flags to preload "global" libraries like `babel/register` or `dotenv/config`—I find it convenient for applying the same libs across various scripts in my project without the boilerplate in the code. It would be cool if I could do the same to drop Bluebird in as a replacement to native promises.

Obviously, feel free to say you'd rather not have this in Bluebird core and close this PR—but if it's something you're open to let me know what I can do to make this merge-able and I'd be happy to do so. (One thing right now is because of the way Bluebird's builds one has to `-r bluebird/js/release/register`, where it might be more obvious to `-r bluebird/register`—doesn't really bother me, just wanted to point that out.)

Thanks for your time and consideration. Bluebird is amazing!