### PR TITLE
Revert "Fix anchor link on warning explanations"

### DIFF
--- a/docs/docs/warning-explanations.md
+++ b/docs/docs/warning-explanations.md
@@ -5,7 +5,7 @@ title: Warning Explanations
 
 [warning-explanations](unfinished-article)
 
- - [Warning: .then() only accepts functions](#warning-then-only-accepts-functions)
+ - [Warning: .then() only accepts functions](#warning-.then)
  - [Warning: a promise was rejected with a non-error](#warning-a-promise-was-rejected-with-a-non-error)
  - [Warning: a promise was created in a handler but was not returned from it](#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it)
 


### PR DESCRIPTION
Turns out this broke the link actually. 😅  I didn't realize that redcarpet strips everything after an unacceptable character.