### PR TITLE
Fix 404 link in deferred-migration.md

### DIFF
--- a/docs/docs/api/deferred-migration.md
+++ b/docs/docs/api/deferred-migration.md
@@ -26,7 +26,7 @@ function defer() {
 }
 ```
 
-For old code that still uses deferred objects, see [the deprecated API docs ](/bluebird/web/docs/deprecated_apis.html#promise-resolution).
+For old code that still uses deferred objects, see [the deprecated API docs ](/docs/deprecated-apis.html#promise-resolution).
 </markdown></div>
 
 <div id="disqus_thread"></div>


### PR DESCRIPTION
The current link for `the deprecated API docs` is http://bluebirdjs.com/bluebird/web/docs/deprecated_apis.html#promise-resolution
which is 404.

I believe the correct link is to http://bluebirdjs.com/docs/deprecated-apis.html#promise-resolution