### PR TITLE
[Docs] Fix order of arguments passed to Promise.delay

### DIFF
--- a/docs/docs/coming-from-other-libraries.md
+++ b/docs/docs/coming-from-other-libraries.md
@@ -218,8 +218,8 @@ function(err, results){
 ```
 
 ```js
-Promise.all([Promise.delay('one', 200),
-             Promise.delay('two', 100)]).then(function(results) {
+Promise.all([Promise.delay(200, 'one'),
+             Promise.delay(100, 'two')]).then(function(results) {
     // the results array will equal ['one','two'] even though
     // the second function had a shorter timeout.
 });


### PR DESCRIPTION
The example doesn't work because `Promise.delay` takes `ms` milliseconds as the first argument.
This small change makes the example work again.