### PR TITLE
Eliminate excess formatting from isFulfilled()|isRejected() docs

### DIFF
--- a/docs/docs/api/isfulfilled.md
+++ b/docs/docs/api/isfulfilled.md
@@ -13,7 +13,7 @@ title: .isFulfilled
 .isFulfilled() -> boolean
 ```
 
-See if this `promise` has been fulfilled.
+See if this promise has been fulfilled.
 </markdown></div>
 
 <div id="disqus_thread"></div>

--- a/docs/docs/api/isrejected.md
+++ b/docs/docs/api/isrejected.md
@@ -13,7 +13,7 @@ title: .isRejected
 .isRejected() -> boolean
 ```
 
-See if this `promise` has been rejected.
+See if this promise has been rejected.
 </markdown></div>
 
 <div id="disqus_thread"></div>


### PR DESCRIPTION
Is there a reason *promise* is marked up as code here? It's not in other places like [`.reason`](https://github.com/petkaantonov/bluebird/blob/c1604826ab17b9804f2c102958af01d1b782ce9a/docs/docs/api/reason.md), [`.value`](https://github.com/petkaantonov/bluebird/blob/c1604826ab17b9804f2c102958af01d1b782ce9a/docs/docs/api/value.md).