### PR TITLE
Fix deprecated APIs URL

### DIFF
--- a/docs/docs/api/deferred-migration.md
+++ b/docs/docs/api/deferred-migration.md
@@ -26,7 +26,7 @@ function defer() {
 }
 ```
 
-For old code that still uses deferred objects, see [the deprecated API docs ](/docs/deprecated-apis.html#promise-resolution).
+For old code that still uses deferred objects, see [the deprecated API docs ](//bluebirdjs.com/docs/deprecated-apis.html#promise-resolution).
 </markdown></div>
 
 <div id="disqus_thread"></div>


### PR DESCRIPTION
For some reason `/docs/deprecated-apis.html` becomes `http://bluebirdjs.com/bluebird/web/docs/deprecated_apis.html`