### PR TITLE
`getNewLibraryCopy` method in v2.x

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -164,6 +164,8 @@ Promise.prototype.error = function (fn) {
     return this.caught(util.originatesFromRejection, fn);
 };
 
+Promise.getNewLibraryCopy = module.exports;
+
 Promise.is = function (val) {
     return val instanceof Promise;
 };

--- a/test/mocha/getNewLibraryCopy.js
+++ b/test/mocha/getNewLibraryCopy.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var assert = require("assert");
+var testUtils = require("./helpers/util.js");
+
+describe("Promise.getNewLibraryCopy", function() {
+    specify("should return an independent copy of Bluebird library", function() {
+        var Promise2 = Promise.getNewLibraryCopy();
+        Promise2.x = 123;
+
+        assert.equal(typeof Promise2.prototype.then, "function");
+        assert.notEqual(Promise2, Promise);
+
+        assert.equal(Promise2.x, 123);
+        assert.notEqual(Promise.x, 123);
+    });
+    specify("should return copy of Bluebird library with its own getNewLibraryCopy method", function() {
+        var Promise2 = Promise.getNewLibraryCopy();
+        var Promise3 = Promise2.getNewLibraryCopy();
+        Promise3.x = 123;
+
+        assert.equal(typeof Promise3.prototype.then, "function");
+        assert.notEqual(Promise3, Promise);
+        assert.notEqual(Promise3, Promise2);
+
+        assert.equal(Promise3.x, 123);
+        assert.notEqual(Promise.x, 123);
+        assert.notEqual(Promise2.x, 123);
+    });
+});


### PR DESCRIPTION
This PR adds the `getNewLibraryCopy` method to bluebird v2.x.

Same as method added to v3.x in PR #1076.