### PR TITLE
Fix typo in docs for `Promise.getNewLibraryCopy`

### DIFF
--- a/docs/docs/api/promise.getnewlibrarycopy.md
+++ b/docs/docs/api/promise.getnewlibrarycopy.md
@@ -30,7 +30,7 @@ console.log(Promise2.x); // 123
 console.log(Promise.x); // undefined
 ```
 
-`Promise` is independent to `Promise`. Any changes to `Promise2` do not affect the copy of Bluebird returned by `require('bluebird')`.
+`Promise2` is independent to `Promise`. Any changes to `Promise2` do not affect the copy of Bluebird returned by `require('bluebird')`.
 
 In practice:
 


### PR DESCRIPTION
This PR fixes a typo in the docs for `Promise.getNewLibraryCopy`. Sorry, my mistake!