### PR TITLE
Repeated subexpression in ast_passes.js

### DIFF
--- a/tools/ast_passes.js
+++ b/tools/ast_passes.js
@@ -53,8 +53,7 @@ function nodeToString( expr ) {
     else if( expr.type === "UnaryExpression" ) {
         if( expr.operator === "~" ||
             expr.operator === "-" ||
-            expr.operator === "+" ||
-            expr.operator === "-" ) {
+            expr.operator === "+" ) {
             return expr.operator + nodeToString( expr.argument );
         }
         return "(" + expr.operator + " " + nodeToString( expr.argument ) + ")";


### PR DESCRIPTION
`expr.operator === "-"` is repeated. Was it meant to be something else, or can it be removed?