### PR TITLE
Making .catch Error Predicates More Descriptive

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -95,7 +95,8 @@ Promise.prototype.caught = Promise.prototype["catch"] = function (fn) {
             if (util.isObject(item)) {
                 catchInstances[j++] = item;
             } else {
-                return apiRejection(OBJECT_ERROR + "A catch statement predicate " + util.classString(item));
+                return apiRejection(OBJECT_ERROR + 
+                    "A catch statement predicate " + util.classString(item));
             }
         }
         catchInstances.length = j;


### PR DESCRIPTION
I spent a while debugging an error in my promise heavy API and a lit of that time could have been mitigated if I had an error that told me that the error occurred as a `.catch` statement predicate. If the error prefix needs to be moved somewhere else, just let me know.  