### PR TITLE
Indicate that .cast is an old alias for Promise.resolve

### DIFF
--- a/docs/docs/api/promise.resolve.md
+++ b/docs/docs/api/promise.resolve.md
@@ -30,6 +30,8 @@ Promise.resolve($.get("http://www.google.com")).then(function() {
     console.log(e.statusText);
 });
 ```
+
+*For compatibility with earlier ECMAScript versions, an alias `.cast` is provided for [`Promise.resolve`](.).*
 </markdown></div>
 
 <div id="disqus_thread"></div>
@@ -37,7 +39,7 @@ Promise.resolve($.get("http://www.google.com")).then(function() {
     var disqus_title = "Promise.resolve";
     var disqus_shortname = "bluebirdjs";
     var disqus_identifier = "disqus-id-promise.resolve";
-    
+
     (function() {
         var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
         dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";


### PR DESCRIPTION
Some old docs/tutorials etc still use `.cast`. Was a bit confusing that it was nowhere to be found in the bluebird docs.