### PR TITLE
Fix Haskell's then's type

### DIFF
--- a/docs/docs/coming-from-other-languages.md
+++ b/docs/docs/coming-from-other-languages.md
@@ -64,7 +64,7 @@ Boost futures expose a `.then` method similar to promises and allow this functio
 A promise is a monadic construct with `.then` filling the role of `>>=` (bind). The major difference is that `.then` performs recursive assimilation which acts like a `flatMap` or a map. The type signature of `then` is quote complicated. If we omit the error argument and not throw - it's similar to:
 
 ```hs
-then::Promise a -> a -> (Either (Promise b) b) -> Promise B
+then::Promise a -> (a -> (Either (Promise b) b)) -> Promise b
 ```
 
 That is, you can return either a promise _or a plain value_ from a `then` without wrapping it.


### PR DESCRIPTION
The then type signature should have (a -> (Either (Promise b) b)) instead of just a -> (Either (Promise b) b). The old type signature of this function is equivalent to:

then :: Promise a -> (a -> ((Either (Promise b) b) -> Promise b))

Which isn't quite right. The type signature for (>>=) reflects my change.

Also the final b was capitalized, which is wrong since Haskell uses lower cased letters as type variables, not upper cased ones.