### PR TITLE
Update value.md

### DIFF
--- a/docs/docs/api/value.md
+++ b/docs/docs/api/value.md
@@ -16,7 +16,7 @@ title: .value
 
 Get the fulfillment value of this promise. Throws an error if the promise isn't fulfilled - it is a bug to call this method on an unfulfilled promise.
 
-You should check if this promise is [.isFulfilled()](.) in code paths where it's guaranteed that this promise is fulfilled.
+You should check if this promise is [.isFulfilled()](.) in code paths where it's not guaranteed that this promise is fulfilled.
 </markdown></div>
 
 <div id="disqus_thread"></div>


### PR DESCRIPTION
Missing word here: presumably `.isFulfilled()` only needs to be called in code paths where it's *not* already guaranteed to be fulfilled.