### PR TITLE
fixed Promise.delay() not capturing long stack trace

### DIFF
--- a/src/timers.js
+++ b/src/timers.js
@@ -27,6 +27,7 @@ var delay = Promise.delay = function (ms, value) {
         if (debug.cancellation()) {
             ret._setOnCancel(new HandleWrapper(handle));
         }
+        ret._captureStackTrace();
     }
     ret._setAsyncGuaranteed();
     return ret;


### PR DESCRIPTION
related to issues #1182 