### PR TITLE
asCallback creates a new promise and continues the chain

### DIFF
--- a/test/mocha/late_buffer_safety.js
+++ b/test/mocha/late_buffer_safety.js
@@ -4,9 +4,6 @@ var assert = require("assert");
 var testUtils = require("./helpers/util.js");
 var isNodeJS = testUtils.isNodeJS;
 
-function async(cb){
-    return Promise.resolve().nodeify(cb);
-}
 
 if (isNodeJS) {
     describe("Late buffer", function() {
@@ -15,9 +12,7 @@ if (isNodeJS) {
             var l = length;
             var a = 0;
             while (l--){
-                async(function(){
-                    throw (a++);
-                });
+                Promise._async.throwLater(a++);
             }
             var errs = [];
             return testUtils.awaitGlobalException(function(e) {

--- a/test/mocha/nodeify.js
+++ b/test/mocha/nodeify.js
@@ -74,17 +74,14 @@ if (isNodeJS) {
             throw e;
         }
 
-        it("throws normally in the node process if the function throws", function() {
-            var promise = Promise.resolve(10);
-            var turns = 0;
-            process.nextTick(function(){
-                turns++;
-            });
-            promise.nodeify(thrower);
-            return awaitGlobalException(function(err) {
-                assert(err === e);
-                assert(turns === 1);
-            });
+        it("catches if the function throws", function() {
+            var spy = sinon.spy();
+            Promise.resolve(3).nodeify(thrower)
+                .catch(spy);
+            setTimeout(function () {
+                sinon.assert.calledOnce(spy);
+                sinon.assert.calledWith(spy, e);
+            }, 1);
         });
 
         it("always returns promise for now", function() {
@@ -175,26 +172,24 @@ if (isNodeJS) {
             return spy.promise;
         });
 
-        it("should work if the callback throws when spread", function() {
-            var err = new Error();
-            Promise.resolve([1,2,3]).nodeify(function(_, a) {
-                throw err;
-            }, {spread: true});
-
-            return awaitGlobalException(function(e) {
-                assert.strictEqual(err, e);
-            });
+        it("should catch if the callback throws when spread", function() {
+            var spy = sinon.spy();
+            Promise.resolve([1, 2, 3]).nodeify(thrower, {spread: true})
+                .catch(spy);
+            setTimeout(function () {
+                sinon.assert.calledOnce(spy);
+                sinon.assert.calledWith(spy, e);
+            }, 1);
         });
 
-        it("should work if the callback throws when rejected", function() {
-            var err = new Error();
-            Promise.reject(new Error()).nodeify(function(_, a) {
-                throw err;
-            });
-
-            return awaitGlobalException(function(e) {
-                assert.strictEqual(err, e);
-            });
+        it("should catch if the callback throws when rejected", function() {
+            var spy = sinon.spy();
+            Promise.reject(new Error()).nodeify(thrower)
+                .catch(spy);
+            setTimeout(function () {
+                sinon.assert.calledOnce(spy);
+                sinon.assert.calledWith(spy, e);
+            }, 1);
         });
     });
 }


### PR DESCRIPTION
This is an alternative solution to the problem discussed in #1194. It changes `asCallback` return a new promise that resolves to the result of the callback or rejects to errors thrown in the callback.

```javascript
Promise.resolve(true)
    .asCallback(function (err, v) {
        return 'text';
    })
    .then(v => {
        console.log(v); //text
    });

Promise.resolve(true)
    .asCallback(function (err, v) {
        throw new Error('error');
    })
    .catch(err => {
        console.log(err.message); //error
    });
```