### PR TITLE
Fixes a regression introduced by #1191 and a problem it overlooked.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ gh-pages
 node_modules
 gh-pages
 test/browser/bundle.js
+test/browser/worker_bundle.js
 js/*
 zalgo.js
 coverage/*

--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -152,7 +152,8 @@ var fireDomEvent = (function() {
             util.global.dispatchEvent(event);
             return function(name, event) {
                 var domEvent = new CustomEvent(name.toLowerCase(), {
-                    detail: event
+                    detail: event,
+                    cancelable: true
                 });
                 return !util.global.dispatchEvent(domEvent);
             };

--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -157,6 +157,18 @@ var fireDomEvent = (function() {
                 });
                 return !util.global.dispatchEvent(domEvent);
             };
+        // In Firefox < 48 CustomEvent is not available in workers but
+        // Event is.
+        } else if (typeof Event === "function") {
+            var event = new Event("CustomEvent");
+            util.global.dispatchEvent(event);
+            return function(name, event) {
+                var domEvent = new Event(name.toLowerCase(), {
+                    cancelable: true
+                });
+                domEvent.detail = event;
+                return !util.global.dispatchEvent(domEvent);
+            };
         } else {
             var event = document.createEvent("CustomEvent");
             event.initCustomEvent("testingtheevent", false, true, {});

--- a/test/browser/promise_debug.js
+++ b/test/browser/promise_debug.js
@@ -1,5 +1,5 @@
 var Promise = require("../../js/browser/bluebird.min.js");
 Promise.longStackTraces();
 Promise.config({cancellation:true});
-window.Promise = Promise;
-window.adapter = Promise;
+self.Promise = Promise;
+self.adapter = Promise;

--- a/test/browser/worker.js
+++ b/test/browser/worker.js
@@ -1,0 +1,20 @@
+self.importScripts("./worker_bundle.js");
+
+var currentPromise;
+
+function handler(ev) {
+    ev.preventDefault();
+    self.postMessage(ev.type);
+    if (ev.type === "unhandledrejection") {
+        currentPromise.catch(function () {});
+    }
+}
+
+self.addEventListener("unhandledrejection", handler);
+self.addEventListener("rejectionhandled", handler);
+
+self.onmessage = function onmessage(ev) {
+    if (ev.data === "reject") {
+        currentPromise = Promise.reject(new Error("rejected"));
+    }
+};


### PR DESCRIPTION
#1191 introduced two regressions:

1. It did not pass properly the details of the event. This was fixed in commit 288aa285fe61d4a9c360253eb5cbb66d04a81c62.

2. It did not make the event cancelable. This PR fixes this.

It also overlooked a problem with Firefox versions earlier than 48. Those versions do not make `CustomEvent` available in workers. It is a bug in Firefox but it is going to bite users of Bluebird unless Bluebird takes action to work around it. The current ESR of Firefox is version 45, which has the bug.

I've also added a test that summarily checks that events raised in workers can be caught with global handlers. Right now I have both `node tools/test`, and `node tools/test --browser` with Firefox pass all tests. 

Unfortunately, the browser tests do not pass on Chrome 51 but I've checked out v3.4.0 and v3.4.3 and found that it does not pass with these versions either. So it is not an issue I've created. (The one test I've added does actually pass on Chrome. 51.)