### PR TITLE
Run Travis CI on Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ matrix:
     - node_js: "0.12"
     - node_js: "4"
     - node_js: "5"
+    - node_js: "6"
   fast_finish: true
 env:
-  - "NODE_FLAGS='' SCRIPT_FLAGS=''"  
+  - "NODE_FLAGS='' SCRIPT_FLAGS=''"
 before_script:
 - git submodule update --init --recursive
 script: "node $NODE_FLAGS tools/test.js $SCRIPT_FLAGS"


### PR DESCRIPTION
This PR adds coverage for Node v6.x to Travis CI run.