### PR TITLE
Quick start example on the "Getting started" page

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -35,22 +35,32 @@ When using script tags the global variables `Promise` and `P` (alias for `Promis
 
 ## Quick start
 
-How to define a function that returns a promise.
+An example function that performs an AJAX request and returns a promise.
 ```javascript
-function doSomething() {
+function doGet() {
   return new Promise(function(resolve, reject) {
-    // Do asynchronous things here, such as an AJAX request or a database look up
-    var result = "Hello world";
+    var xhr = new XMLHttpRequest();
     
-    return resolve(result);
+    xhr.addEventListener("load", function() {
+      resolve(xhr);
+    }, false);
+    
+    xhr.addEventListener("error", function(ev) {
+      resolve(ev.error);
+    });
+    
+    xhr.open("GET", url);
+    xhr.send(null);
   });
 }
 ```
 
 How to use your newly created function.
 ```javascript
-doSomething().then(function(result) {
-  // result is now "Hello world"
+doGet().then(function(xhr) {
+  // Do something with the result
+}).error(function(error) {
+  // Handle the error
 });
 ```
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -32,3 +32,26 @@ There are many ways to use bluebird in browsers:
 - You may use the [bower](http://bower.io) package.
 
 When using script tags the global variables `Promise` and `P` (alias for `Promise`) become available. Bluebird runs on a wide variety of browsers including older versions. We'd like to thank BrowserStack for giving us a free account which helps us test that. 
+
+## Quick start
+
+How to define a function that returns a promise.
+```javascript
+function doSomething() {
+  return new Promise(function(resolve, reject) {
+    // Do asynchronous things here, such as an AJAX request or a database look up
+    var result = "Hello world";
+    
+    return resolve(result);
+  });
+}
+```
+
+How to use your newly created function.
+```javascript
+doSomething().then(function(result) {
+  // result is now "Hello world"
+});
+```
+
+For more information, please read the [API Reference](api-reference.html).


### PR DESCRIPTION
Took me 5 minutes to figure out how to do the simplest thing – to return a promise and act upon it. I had to dig through the "API reference" and look for things that seemed appropriate. 

The "Getting started" guide only mentions installation, but would definitely benefit from a quick start example. The API reference is definitely good for more detailed information, but the "quick start" should suffice for lots of new users who just want to use promises in their own methods.
