### PR TITLE
fix: ensure that property is writable and configurable

### DIFF
--- a/src/es5.js
+++ b/src/es5.js
@@ -15,7 +15,24 @@ if (isES5) {
         isES5: isES5,
         propertyIsWritable: function(obj, prop) {
             var descriptor = Object.getOwnPropertyDescriptor(obj, prop);
-            return !!(!descriptor || descriptor.writable || descriptor.set);
+
+            if (!descriptor) {
+                return true;
+            }
+
+            if (descriptor.set) {
+                return true;
+            }
+
+            if (descriptor.writable !== true) {
+                return false;
+            }
+
+            if (descriptor.configurable !== true) {
+                return false;
+            }
+
+            return true;
         }
     };
 } else {


### PR DESCRIPTION
A property thats writable but not configurable cannot be overwitten.
Attempting to overwrite a non-configurable property will result in
error equivalent to:

```
TypeError: Cannot redefine property: stack
```