### PR TITLE
add isCancelled() regression tests

### DIFF
--- a/test/mocha/cancel.js
+++ b/test/mocha/cancel.js
@@ -281,7 +281,7 @@ describe("Cancellation", function() {
         });
     });
 
-    specify("Can be used for breaking chains early", function() {
+    specify("can be used for breaking chains early", function() {
         var called = false;
         var p = Promise.resolve(1)
             .then(function(data) {
@@ -709,7 +709,21 @@ describe("Cancellation", function() {
         req.cancel();
         var resolve;
         return new Promise(function(_, __, onCancel) {resolve = arguments[0]});
-    })
+    });
+
+    specify("isCancelled() synchronously returns true after calling cancel() on pending promise", function() {
+        var resolver = Promise.pending();
+        resolver.promise.cancel();
+        assert(resolver.promise.isCancelled());
+    });
+
+    specify("isCancelled() synchronously returns true after calling cancel() on promise created from .then()", function() {
+        var resolver = Promise.pending();
+        var thenPromise = resolver.promise.then();
+        thenPromise.cancel();
+        assert(thenPromise.isCancelled());
+    });
+
     specify("gh-166", function() {
         var f1 = false, f2 = false, f3 = false, f4 = false;
         var a = Promise.resolve();

--- a/test/mocha/cancel.js
+++ b/test/mocha/cancel.js
@@ -712,14 +712,14 @@ describe("Cancellation", function() {
     });
 
     specify("isCancelled() synchronously returns true after calling cancel() on pending promise", function() {
-        var resolver = Promise.pending();
-        resolver.promise.cancel();
-        assert(resolver.promise.isCancelled());
+        var promise = new Promise(function () {});
+        promise.cancel();
+        assert(promise.isCancelled());
     });
 
     specify("isCancelled() synchronously returns true after calling cancel() on promise created from .then()", function() {
-        var resolver = Promise.pending();
-        var thenPromise = resolver.promise.then();
+        var promise = new Promise(function () {});
+        var thenPromise = promise.then();
         thenPromise.cancel();
         assert(thenPromise.isCancelled());
     });


### PR DESCRIPTION
Adding some regression tests around isCancelled(). These tests are green against bluebird master:

<img width="517" alt="screen shot 2016-09-19 at 8 09 39 am" src="https://cloud.githubusercontent.com/assets/1305608/18637291/c25123ea-7e40-11e6-9b15-3df02e555e77.png">

In our fork of bluebird, we moved over from bluebird2 to bluebird3 a few months ago so we're on a slightly older version of bluebird still. We have some issues with this version around cancellation, and the second unit test here isolates one of these issues - it fails in our fork:

<img width="519" alt="screen shot 2016-09-19 at 8 10 10 am" src="https://cloud.githubusercontent.com/assets/1305608/18637363/f9851182-7e40-11e6-9d82-746f8d83a7fd.png">

Looks like we can merge the latest release of bluebird to fix the issue on our side. Adding these tests to protect this behavior.
