### PR TITLE
relax directory check

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -254,8 +254,8 @@ function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, npmPackage,
 
 var root = process.cwd();
 // Since rm -rf is called, better be sure...
-if (path.basename(root).toLowerCase() !== "bluebird") {
-    throw new Error("cwd must be se to bluebird project root. Cwd is currently\n\n" +
+if (path.basename(root).toLowerCase().indexOf("bluebird") !== 0) {
+    throw new Error("cwd must be set to bluebird project root. cwd is currently\n\n" +
         "         " + process.cwd() + "\n");
 }
 var dirs = {


### PR DESCRIPTION
I have several bluebird repos in the same parent directory and I suffix them differently to distinguish them (e.g. `bluebird/` for petkaantonov/bluebird, and `bluebird-finnigantime/` for my fork of it). There is a check in build.js that prevents building/testing if the directory does not exactly match "bluebird". Here's a suggestion to relax that check to just check for "bluebird" at the beginning of the directory string, which I think still provides the same value while allowing multiple bluebird repos with different suffixes to coexist in the same parent directory.

Manually tested that the check still works:
<img width="491" alt="screen shot 2016-09-19 at 8 18 08 am" src="https://cloud.githubusercontent.com/assets/1305608/18637678/12a40a0a-7e42-11e6-92da-978e3d58e466.png">
