### PR TITLE
Deprecate message for Promise.cast

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -189,7 +189,7 @@ Promise.all = function (promises) {
     return new PromiseArray(promises).promise();
 };
 
-Promise.cast = function (obj) {
+Promise.resolve = function (obj) {
     var ret = tryConvertToPromise(obj);
     if (!(ret instanceof Promise)) {
         ret = new Promise(INTERNAL);
@@ -200,7 +200,12 @@ Promise.cast = function (obj) {
     return ret;
 };
 
-Promise.resolve = Promise.fulfilled = Promise.cast;
+Promise.cast = function (obj) {
+  debug.deprecated("Promise.cast", "Promise.resolve");
+  return Promise.resolve(obj);
+};
+
+Promise.fulfilled = Promise.resolve;
 
 Promise.reject = Promise.rejected = function (reason) {
     var ret = new Promise(INTERNAL);


### PR DESCRIPTION
Promise.cast has been deprecated as mentioned here https://github.com/petkaantonov/bluebird/issues/590
