### PR TITLE
Fixed confusing use of thenReturn in code example

### DIFF
--- a/docs/docs/api/return.md
+++ b/docs/docs/api/return.md
@@ -49,7 +49,7 @@ var baseDir = process.argv[2] || ".";
 
 function writeFile(path, contents) {
     var fullpath = require("path").join(baseDir, path);
-    return fs.writeFileAsync(fullpath, contents).thenReturn(fullpath);
+    return fs.writeFileAsync(fullpath, contents).return(fullpath);
 }
 
 writeFile("test.txt", "this is text").then(function(fullPath) {


### PR DESCRIPTION
Replaced the confusing use of the legacy .thenReturn() in the last code example with the expected .return() instead.
