### PR TITLE
Promise.reject() doesn't cause OperationalError wrapping since 3.0

### DIFF
--- a/docs/docs/api/operationalerror.md
+++ b/docs/docs/api/operationalerror.md
@@ -14,8 +14,7 @@ new OperationalError(String message) -> OperationalError
 ```
 
 
-Represents an error is an explicit promise rejection as opposed to a thrown error. For example, if an error is errbacked by a callback API promisified through undefined or undefined
-and is not a typed error, it will be converted to a `OperationalError` which has the original error in the `.cause` property.
+Represents an error is the result of a node-style errback from a promisified API call. For example, if an error is errbacked by a callback API promisified through undefined or undefined and is not a typed error, it will be converted to a `OperationalError` which has the original error in the `.cause` property.
 
 `OperationalError`s are caught in [`.error`](.) handlers.
 </markdown></div>


### PR DESCRIPTION
Update OperationalError docs, which documented pre-3.0 behavior.