### PR TITLE
Added stack detection for Edge.

### DIFF
--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -860,6 +860,20 @@ var captureStackTrace = (function stackDetection() {
         };
     }
 
+    //Edge
+    if (typeof err.stack === "string" &&
+        typeof Error.stackTraceLimit === "number" &&
+        v8stackFramePattern.test(err.stack.split("\n")[1])) {
+        stackFramePattern = v8stackFramePattern;
+        formatStack = v8stackFormatter;
+        return function captureStackTrace(o)
+        {
+            Error.stackTraceLimit += 6;
+            o.stack = new Error().stack;
+            Error.stackTraceLimit -= 6;
+        };
+    }
+
     var hasStackAfterThrow;
     try { throw new Error(); }
     catch(e) {


### PR DESCRIPTION
Changed captureStackTrace so that it detects the MS Edge browser for long stack trace support.

Couldn't find unit tests for the other browser checks so I didn't add one.