### PR TITLE
Add missing semicolons in promise.coroutine.md

### DIFF
--- a/docs/docs/api/promise.coroutine.md
+++ b/docs/docs/api/promise.coroutine.md
@@ -23,15 +23,15 @@ function PingPong() {
 }
 
 PingPong.prototype.ping = Promise.coroutine(function* (val) {
-    console.log("Ping?", val)
-    yield Promise.delay(500)
-    this.pong(val+1)
+    console.log("Ping?", val);
+    yield Promise.delay(500);
+    this.pong(val+1);
 });
 
 PingPong.prototype.pong = Promise.coroutine(function* (val) {
-    console.log("Pong!", val)
+    console.log("Pong!", val);
     yield Promise.delay(500);
-    this.ping(val+1)
+    this.ping(val+1);
 });
 
 var a = new PingPong();


### PR DESCRIPTION
Some lines are missing semicolons. The other documentation examples seem to use it.