### PR TITLE
Delay Error.stack until the last possible moment

### DIFF
--- a/src/generators.js
+++ b/src/generators.js
@@ -30,7 +30,7 @@ function promiseFromYieldHandler(value, yieldHandlers, traceParent) {
     return null;
 }
 
-function PromiseSpawn(generatorFunction, receiver, yieldHandler, stack) {
+function PromiseSpawn(generatorFunction, receiver, yieldHandler, context) {
     if (debug.cancellation()) {
         var internal = new Promise(INTERNAL);
         var _finallyPromise = this._finallyPromise = new Promise(INTERNAL);
@@ -43,7 +43,7 @@ function PromiseSpawn(generatorFunction, receiver, yieldHandler, stack) {
         var promise = this._promise = new Promise(INTERNAL);
         promise._captureStackTrace();
     }
-    this._stack = stack;
+    this._context = context;
     this._generatorFunction = generatorFunction;
     this._receiver = receiver;
     this._generator = undefined;
@@ -162,7 +162,7 @@ PromiseSpawn.prototype._continue = function (result) {
                     new TypeError(
                         YIELDED_NON_PROMISE_ERROR.replace("%s", value) +
                         FROM_COROUTINE_CREATED_AT +
-                        this._stack.split("\n").slice(1, -7).join("\n")
+                        this._context.stack.split("\n").slice(1, -7).join("\n")
                     )
                 );
                 return;
@@ -196,11 +196,11 @@ Promise.coroutine = function (generatorFunction, options) {
     }
     var yieldHandler = Object(options).yieldHandler;
     var PromiseSpawn$ = PromiseSpawn;
-    var stack = new Error().stack;
+    var context = new Error();
     return function () {
         var generator = generatorFunction.apply(this, arguments);
         var spawn = new PromiseSpawn$(undefined, undefined, yieldHandler,
-                                      stack);
+                                      context);
         var ret = spawn.promise();
         spawn._generator = generator;
         spawn._promiseFulfilled(undefined);


### PR DESCRIPTION
Accessing Error.stack is about 10 times slower than creating a new Error in vanilla Node.JS. This is made orders of magnitude worse when using coffeescript or a stack beautification lib that further changes the trace. As such, it should only ever be used when needed. The current implementation of `Promise.coroutine` obtains the stack whenever a generator is converted to a promise and while this is a one-time cost per promisified generator, if called from within a closure this needlessly obtains the stack when everything is working as expected.

This changes that behavior to only call .stack when the returned promise will throw. While benchmarking, I observed that accessing the .stack property appears to have a similar performance profile with a cached function, so local caching shouldn't be needed. It might make sense to cache the extra .split().slice().join() chain, but I believe that should be a separate PR.

Benchmark: https://gist.github.com/za-creature/28ca43947ee2c0a7ead33558ac4a9fa1
Results (Node.JS 4.6.1):
```
Different error w/o stack 484
Different error w/ stack 4809
Different error w/ stack w/o reuse 5241
Same error w/ stack w/ plain reuse 4886
Same error w/ stack w/ cached reuse 5209
```