### PR TITLE
Fix for #1280 - Don't drop SyntaxError context for longStackTraces

### DIFF
--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -575,7 +575,7 @@ function stackFramesAsArray(error) {
         }
     }
     // Chrome and IE include the error message in the stack
-    if (i > 0) {
+    if (i > 0 && error.name != "SyntaxError") {
         stack = stack.slice(i);
     }
     return stack;
@@ -588,7 +588,7 @@ function parseStackAndMessage(error) {
                 ? stackFramesAsArray(error) : [NO_STACK_TRACE];
     return {
         message: message,
-        stack: cleanStack(stack)
+        stack: error.name == "SyntaxError" ? stack : cleanStack(stack)
     };
 }
 


### PR DESCRIPTION
SyntaxErrors in node.js are different from other Errors in JS - the first 3 lines of the stack specify the file, lineno, and code snippet where the error occurred. Previously, longStackTraces were stripping this information, which made identifying the fix problematic. This diff keeps this info in the stack.

(was #1281)