### PR TITLE
Fixed #1314:  yielding a function should not call the function

### DIFF
--- a/src/generators.js
+++ b/src/generators.js
@@ -160,8 +160,7 @@ PromiseSpawn.prototype._continue = function (result) {
             if (maybePromise === null) {
                 this._promiseRejected(
                     new TypeError(
-                        YIELDED_NON_PROMISE_ERROR.replace("%s", 
-                            value == null ? value : value.toString()) +
+                        YIELDED_NON_PROMISE_ERROR.replace("%s", String(value)) +
                         FROM_COROUTINE_CREATED_AT +
                         this._stack.split("\n").slice(1, -7).join("\n")
                     )

--- a/src/generators.js
+++ b/src/generators.js
@@ -160,7 +160,8 @@ PromiseSpawn.prototype._continue = function (result) {
             if (maybePromise === null) {
                 this._promiseRejected(
                     new TypeError(
-                        YIELDED_NON_PROMISE_ERROR.replace("%s", value) +
+                        YIELDED_NON_PROMISE_ERROR.replace("%s", 
+                            value == null ? value : value.toString()) +
                         FROM_COROUTINE_CREATED_AT +
                         this._stack.split("\n").slice(1, -7).join("\n")
                     )


### PR DESCRIPTION
When rejecting a non-promise value, string.replace is used, and the value is passed as second parameter. But string.replace, if the second parameter is a function, will call that function.
This commit fixes this by using value.toString().