### PR TITLE
Fixed #1260: Add current line in creatorLog for debugging purpose

### DIFF
--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -457,6 +457,9 @@ function checkForgottenReturns(returnValue, promiseCreated, name, promise,
                     if (traceLines[i] === firstUserLine) {
                         if (i > 0) {
                             creatorLine = "\n" + traceLines[i - 1];
+                             if(traceLines[i]){
+                                creatorLine += "\n" + traceLines[i];
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
creatorLine take his lines from traceLines, but we have a variable "stack" that takes that traceLines and clean it (using cleanStack Fonction). 

In my case (you can check it on the issue), if we add to previous line the current line (with a verification in order to be sure that it exist as I'm not sure about why this has been done like that in first place). It fixes the problem. 
The fact that we do not delete anything avoid any regression (the first line will still be there), but add a new information (the second line) if it's available.