### PR TITLE
Update promise.each.md

### DIFF
--- a/docs/docs/api/promise.each.md
+++ b/docs/docs/api/promise.each.md
@@ -19,10 +19,9 @@ Promise.each(
 
 [api/promise.each](unfinished-article)
 
-Iterate over an array, or a promise of an array, which contains promises (or a mix of promises and values) with the given `iterator` function with the signature `(value, index, length)` where `value` is the resolved value of a respective promise in the input array. **Iteration happens serially**. If any promise in the input array is rejected the returned promise is rejected as well.
+Iterate over an array, or a promise of an array, which contains promises (or a mix of promises and values) with the given `iterator` function with the signature `(value, index, length)` where `value` is the resolved value of a respective promise in the input array. **Iteration happens serially**. If the iterator function returns a promise or a thenable, then the result of the promise is awaited before continuing with next iteration. If any promise in the input array is rejected, then the returned promise is rejected as well.
 
-Resolves to the original array unmodified, this method is meant to be used for side effects. If the iterator function returns a promise or a thenable, then the result of the promise is awaited, before continuing with next iteration.
-
+Resolves to the original array unmodified. This method is meant to be used for side effects. 
 
 <hr>
 </markdown></div>


### PR DESCRIPTION
I fixed a few grammatical issues and moved the sentence "If the iterator function returns a promise..." to the first paragraph where it seems to belong since it's part of the iterator logic. It's a pretty important thing to keep in mind and it seemed like an afterthought.

I also posted a few examples in the comments at http://bluebirdjs.com/docs/api/promise.each.html of using `.each`. I think these examples are helpful because people seem to think that passing an array of promises to `.each` means the promises haven't executed yet, which is not the case, and the examples that I wrote demonstrate how to achieve just that. Are there guidelines for writing examples? Can they be further refined and included in the docs on this page?