### PR TITLE
Added dedicated webpack entry point.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "readmeFilename": "README.md",
   "main": "./js/release/bluebird.js",
+  "webpack": "./js/release/bluebird.js",
   "browser": "./js/browser/bluebird.js",
   "files": [
     "js/browser",


### PR DESCRIPTION
I'm using Bluebird 3.4.7 with webpack 1 and noticed it was clobbering the global variable `P`. I could see the snippet at the end of the script that it puts itself in the global namespace.

```js
                       ;if (typeof window !== 'undefined' && window !== null) {
                             window.P = window.Promise;
                        } else if (typeof self !== 'undefined' && self !== null) {
                             self.P = self.Promise;
                        }
```

I investigated a bit and found out that webpack will use the "browser" field from package.json if it's available. From [the webpack docs](http://webpack.github.io/docs/configuration.html#resolve-packagemains):

> Check these fields in the package.json for suitable files.
> Default: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"]

This means that webpack picks the "browser" version instead of "main". Running webpack --display-modules confirmed it:

```
[5] ./~/bluebird/js/browser/bluebird.js 178 kB {0} [built]
```

Since Blubird's [installation docs](http://bluebirdjs.com/docs/install.html#browserify-and-webpack) do not mention it, I think it's expected to include `release/bluebird.js` from the `main` field.