### PR TITLE
Fix typo which mentioned that tap was called for rejections.

### DIFF
--- a/docs/docs/api/tap.md
+++ b/docs/docs/api/tap.md
@@ -14,7 +14,7 @@ title: .tap
 ```
 
 
-Like [`.finally`](.) that is not called for rejections.
+Unlike [`.finally`](.) this is not called for rejections.
 
 ```js
 getUser().tap(function(user) {


### PR DESCRIPTION
As shown in this [example](https://runkit.com/58a6215425e6da0013370a71/58a6215425e6da0013370a72/branches/master) `.tap` is not called when there is a rejection. This fixes the text to correctly represent that in the docs.