### PR TITLE
Reword the catch predicate TypeError message for clarity

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -95,8 +95,8 @@ Promise.prototype.caught = Promise.prototype["catch"] = function (fn) {
             if (util.isObject(item)) {
                 catchInstances[j++] = item;
             } else {
-                return apiRejection(OBJECT_ERROR +
-                    "A catch statement predicate " + util.classString(item));
+                return apiRejection("Catch statement predicate: " +
+                    OBJECT_ERROR + util.classString(item));
             }
         }
         catchInstances.length = j;


### PR DESCRIPTION
If `.catch` is passed a non-object instead of a predicate, I found the current error message a bit difficult to read:

> TypeError: expecting an object but got A catch statement predicate [object String]

New error message: 

> TypeError: Catch statement predicate: expecting an object but got [object String]

(Sorry if you don't like these sort of "trivial" pull requests)