### PR TITLE
Fix link to tapCatch documentation

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -67,7 +67,7 @@ redirect_from: "/docs/api/index.html"
     - [Promise.coroutine.addYieldHandler](api/promise.coroutine.addyieldhandler.html)
 - [Utility](api/utility.html)
     - [.tap](api/tap.html)
-    - [.tapCatch](api/tapCatch.html)
+    - [.tapCatch](api/tapcatch.html)
     - [.call](api/call.html)
     - [.get](api/get.html)
     - [.return](api/return.html)


### PR DESCRIPTION
Actual documentation lives at `api/tapcatch.html`, not `api/tapCatch.html`.