### PR TITLE
Push to queue in reverse order.

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -62,7 +62,7 @@ MappingPromiseArray.prototype._promiseFulfilled = function (value, index) {
     } else {
         if (limit >= 1 && this._inFlight >= limit) {
             values[index] = value;
-            this._queue.push(index);
+            this._queue.push(length+limit-index-1);
             return false;
         }
         if (preservedValues !== null) preservedValues[index] = value;

--- a/test/mocha/map.js
+++ b/test/mocha/map.js
@@ -285,10 +285,10 @@ describe("Promise.map-test with concurrency", function () {
             assert.deepEqual(b, [0, 1, 2, 3, 4]);
             lates.forEach(resolve);
         }).delay(100).then(function() {
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6 ]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
             lates.forEach(resolve);
         }).thenReturn(ret1).then(function() {
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6, 5]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         });
         return Promise.all([ret1, ret2]);
     });


### PR DESCRIPTION
Push to queue in reverse order. As .pop() is used for efficiency to pull from the end of the array effectively reversing it again, the end result is a saner execution order. Relates to #708.