### PR TITLE
avoid unexpected unhandledRejection

### DIFF
--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -37,9 +37,12 @@ Promise.prototype.suppressUnhandledRejections = function() {
 };
 
 Promise.prototype._ensurePossibleRejectionHandled = function () {
-    if ((this._bitField & IS_REJECTION_IGNORED) !== 0) return;
-    this._setRejectionIsUnhandled();
-    async.invokeLater(this._notifyUnhandledRejection, this, undefined);
+    var promise = this;
+    if ((promise._bitField & IS_REJECTION_IGNORED) !== 0) return;
+    promise._setRejectionIsUnhandled();
+    async.throwLater(function() {
+        promise._notifyUnhandledRejection();
+    }, undefined);
 };
 
 Promise.prototype._notifyUnhandledRejectionIsHandled = function () {


### PR DESCRIPTION
I fixed this issue. https://github.com/petkaantonov/bluebird/issues/1404
Could you review it?

I wanted to add these cases, but there is no `async/await` test case. Therefore I didn't. (If you want, I will add them..)

### example 0

```js
async function WaitAsync(){
    return Promise.reject(new Error("reject"));
}

Promise.resolve().then(() => {
    return WaitAsync();
}).catch(err => {
    console.log("caught: ", err.message);
});
```
```
caught:  reject
```

### example 1
```js
Promise.using(Promise.resolve(), async () => {
  await Promise.reject(new Error('foo'))
})
.catch(() => console.log('OK'))
```

```
OK
```

### example 2
```js
const reject = () => Promise.reject(new Error('foo'))

Promise.using(Promise.resolve(), async () => {
  await reject()
})
.catch(() => console.log('OK'))
```

```
OK
```
