### PR TITLE
improve .all() docs

### DIFF
--- a/docs/docs/api/all.md
+++ b/docs/docs/api/all.md
@@ -13,7 +13,9 @@ title: .all
 .all() -> Promise
 ```
 
-Same as [Promise.all(this)](.).
+Consume the resolved [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and wait for all items to fulfill similar to [Promise.all()](.).
+
+[Promise.resolve(iterable).all()](.) is the same as [Promise.all(iterable)](.).
 </markdown></div>
 
 <div id="disqus_thread"></div>


### PR DESCRIPTION
the existing docs are unclear about the method consuming the value from the previous promise.

feel free to correct me if its doesn't match the docs style and phrasing