### PR TITLE
Add direct link to Promise.delay from API ref

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -58,6 +58,7 @@ redirect_from: "/docs/api/index.html"
     - [Promise.fromCallback](api/promise.fromcallback.html)
     - [.asCallback](api/ascallback.html)
 - [Timers](api/timers.html)
+    - [Promise.delay](api/promise.delay.html)
     - [.delay](api/delay.html)
     - [.timeout](api/timeout.html)
 - [Cancellation](api/cancellation.html)


### PR DESCRIPTION
The current link from the API ref goes to `.delay`, but that page refers to `Promise.delay`. This will add a direct link to the already existing page.