### PR TITLE
Create await-all.js

### DIFF
--- a/src/await-all.js
+++ b/src/await-all.js
@@ -1,0 +1,30 @@
+"use strict";
+module.exports = function(
+    Promise
+) {
+    function awaitAll(promises) {
+        let resolves = []
+        let rejects = []
+        let _promises = [];
+        // This function can be changed by any other iterator
+        for (let promise of promises) {
+            _promises.push(
+                // Promising each element
+                Promise.resolve(promise)
+                    .then(res => resolves.push(res))
+                    .catch(res => rejects.push(res))
+            )
+        }
+
+        // It has to be defined after all
+        return Promise.all(_promises)
+            .then(() => {
+                if (rejects.length === 0) {
+                    return Promise.resolve(resolves);
+                }
+                return Promise.reject(rejects);
+            })
+    }
+    
+    Promise.awaitAll = Promise.prototype.awaitAll = awaitAll;
+}


### PR DESCRIPTION
This function is something like `Promise.all()`, but wait for all promises, and if one or more of them are failed -- reject array of error results. If all are fine -- same, but resolve (same as `.all()`).

PS: I'll add tests for the function later. Just keep this PR for this day here.