### PR TITLE
Make it more clear that .all is parallel

### DIFF
--- a/docs/docs/api/promise.all.md
+++ b/docs/docs/api/promise.all.md
@@ -15,7 +15,7 @@ Promise.all(Iterable<any>|Promise<Iterable<any>> input) -> Promise<Array<any>>
 
 This method is useful for when you want to wait for more than one promise to complete.
 
-Given an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)\(arrays are `Iterable`\), or a promise of an `Iterable`, which produces promises (or a mix of promises and values), iterate over all the values in the `Iterable` into an array and return a promise that is fulfilled when all the items in the array are fulfilled. The promise's fulfillment value is an array with fulfillment values at respective positions to the original array. If any promise in the array rejects, the returned promise is rejected with the rejection reason.
+Given an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)\(arrays are `Iterable`\), or a promise of an `Iterable`, which produces promises (or a mix of promises and values), iterate over all the values in the `Iterable` into an array and return a promise that is fulfilled when all the items in the array are fulfilled. **Iteration happens in parallel**. The promise's fulfillment value is an array with fulfillment values at respective positions to the original array. If any promise in the array rejects, the returned promise is rejected with the rejection reason.
 
 
 ```js


### PR DESCRIPTION
This goes hand in hand with https://github.com/petkaantonov/bluebird/blob/master/docs/docs/api/promise.each.md where it's stated that iteration is serial.