### PR TITLE
Fix Promise.map unhandled rejections (#1487)

### DIFF
--- a/test/mocha/map.js
+++ b/test/mocha/map.js
@@ -103,8 +103,13 @@ describe("Promise.map-test", function () {
     });
 
     specify("should reject when input contains rejection", function() {
-        var input = [Promise.resolve(1), Promise.reject(2), Promise.resolve(3)];
-        return Promise.map(input, mapper).then(
+        var input = [Promise.resolve(1), Promise.reject(2), Promise.reject(3)];
+        var promise = Promise.map(input, mapper);
+
+        assert(!input[1]._isRejectionUnhandled());
+        assert(!input[2]._isRejectionUnhandled());
+
+        return promise.then(
             assert.fail,
             function(result) {
                 assert(result === 2);
@@ -232,8 +237,13 @@ describe("Promise.map-test with concurrency", function () {
     });
 
     specify("should reject when input contains rejection with concurrency", function() {
-        var input = [Promise.resolve(1), Promise.reject(2), Promise.resolve(3)];
-        return Promise.map(input, mapper, concurrency).then(
+        var input = [Promise.resolve(1), Promise.reject(2), Promise.reject(3)];
+        var promise = Promise.map(input, mapper, concurrency);
+
+        assert(!input[1]._isRejectionUnhandled());
+        assert(!input[2]._isRejectionUnhandled());
+
+        return promise.then(
             assert.fail,
             function(result) {
                 assert(result === 2);


### PR DESCRIPTION
This PR fixes #1487.

Previously, unhandled rejection errors can occur with `Promise.map()`, `Promise.filter()`, `.map()` and `.filter()` when in fact the rejections are handled.

Prior to this PR, all of the following create an unhandled rejection, after this PR they do not.

```js
var p = Promise.reject( new Error('foo') );
Promise.map( p, () => {} ).catch( () => {} );

var arr = [ Promise.reject( new Error('foo') ) ];
Promise.map( arr, () => {} ).catch( () => {} );

var p = Promise.reject( new Error('foo') );
p.map( () => {} ).catch( () => {} );

var arr = [ Promise.reject( new Error('foo') ) ];
var p = Promise.resolve( arr );
p.map( () => {} ).catch( () => {} );


var p = Promise.reject( new Error('foo') );
Promise.filter( p, () => {} ).catch( () => {} );

var arr = [ Promise.reject( new Error('foo') ) ];
Promise.filter( arr, () => {} ).catch( () => {} );

var p = Promise.reject( new Error('foo') );
p.filter( () => {} ).catch( () => {} );

var arr = [ Promise.reject( new Error('foo') ) ];
var p = Promise.resolve( arr );
p.filter( () => {} ).catch( () => {} );
```

I have not written tests as I'm not sure how to test for unhandled rejections.