### PR TITLE
Remove dead code in Queue.prototype.push

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -38,7 +38,6 @@ Queue.prototype.push = function (fn, receiver, arg) {
         return;
     }
     var j = this._front + length - 3;
-    this._checkCapacity(length);
     var wrapMask = this._capacity - 1;
     this[(j + 0) & wrapMask] = fn;
     this[(j + 1) & wrapMask] = receiver;


### PR DESCRIPTION
This PR removes one line of unnecessary code in `queue.js`.

`this._checkCapacity(length)` will never do anything as the eventuality where queue is over capacity has already been checked for by `this._willBeOverCapacity(length)` a few lines earlier.