### PR TITLE
Guard against falsey process.versions to support React Native

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -385,8 +385,12 @@ var ret = {
     domainBind: domainBind
 };
 ret.isRecentNode = ret.isNode && (function() {
-    var version = process.versions.node.split(".").map(Number);
-    return (version[0] === 0 && version[1] > 10) || (version[0] > 0);
+    if (process.versions) {
+        var version = process.versions.node.split(".").map(Number);
+        return (version[0] === 0 && version[1] > 10) || (version[0] > 0);
+    }
+
+    return false
 })();
 
 if (ret.isNode) ret.toFastProperties(process);


### PR DESCRIPTION
I ran into this issue when working on a React Native project. When I imported bluebird, it would throw `Cannot read property 'node' of undefined` and I had to work around the problem by using `Object.defineProperty(process, 'versions', ...)` to get bluebird to work.

Strangely, this "bug" only became a problem after using bluebird in the project for a month or so. I haven't hunted down the culprit but it is are populating `global.process` with an `[object process]` 

I'm not sure if this is really the correct change, since this logic effects whether setImmediate/process.nextTick is used, and we probably want to use setImmediate in a React Native environment.