### PR TITLE
Fix memory being retained until promise queue is completely empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 git:
   depth: 5
 env:
-  - "NODE_FLAGS='' SCRIPT_FLAGS=''"
+  - "NODE_FLAGS='--expose-gc' SCRIPT_FLAGS=''"
 before_script:
 - git submodule update --init --recursive
 script: "node $NODE_FLAGS tools/test.js $SCRIPT_FLAGS"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "lint": "node scripts/jshint.js",
-    "test": "node tools/test.js",
+    "test": "node --expose-gc tools/test.js",
     "istanbul": "istanbul",
     "prepublish": "npm run generate-browser-core && npm run generate-browser-full",
     "generate-browser-full": "node tools/build.js --no-clean --no-debug --release --browser --minify",

--- a/src/async.js
+++ b/src/async.js
@@ -134,11 +134,17 @@ if (!util.hasDevTools) {
 
 Async.prototype._drainQueue = function(queue) {
     while (queue.length() > 0) {
-        var fn = queue.shift();
-        if (typeof fn !== "function") {
-            fn._settlePromises();
-            continue;
-        }
+        this._drainQueueStep(queue);
+    }
+};
+
+// Shift the queue in a separate function to allow
+// garbage collection after each step
+Async.prototype._drainQueueStep = function (queue) {
+    var fn = queue.shift();
+    if (typeof fn !== "function") {
+        fn._settlePromises();
+    } else {
         var receiver = queue.shift();
         var arg = queue.shift();
         fn.call(receiver, arg);

--- a/src/async.js
+++ b/src/async.js
@@ -132,15 +132,15 @@ if (!util.hasDevTools) {
     };
 }
 
-Async.prototype._drainQueue = function(queue) {
+function _drainQueue(queue) {
     while (queue.length() > 0) {
-        this._drainQueueStep(queue);
+        _drainQueueStep(queue);
     }
-};
+}
 
 // Shift the queue in a separate function to allow
 // garbage collection after each step
-Async.prototype._drainQueueStep = function (queue) {
+function _drainQueueStep(queue) {
     var fn = queue.shift();
     if (typeof fn !== "function") {
         fn._settlePromises();
@@ -149,14 +149,14 @@ Async.prototype._drainQueueStep = function (queue) {
         var arg = queue.shift();
         fn.call(receiver, arg);
     }
-};
+}
 
 Async.prototype._drainQueues = function () {
     ASSERT(this._isTickUsed);
-    this._drainQueue(this._normalQueue);
+    _drainQueue(this._normalQueue);
     this._reset();
     this._haveDrainedQueues = true;
-    this._drainQueue(this._lateQueue);
+    _drainQueue(this._lateQueue);
 };
 
 Async.prototype._queueTick = function () {

--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -127,6 +127,7 @@ Promise.longStackTraces = function () {
     if (!config.longStackTraces && longStackTracesIsSupported()) {
         var Promise_captureStackTrace = Promise.prototype._captureStackTrace;
         var Promise_attachExtraTrace = Promise.prototype._attachExtraTrace;
+        var Promise_dereferenceTrace = Promise.prototype._dereferenceTrace;
         config.longStackTraces = true;
         disableLongStackTraces = function() {
             if (async.haveItemsQueued() && !config.longStackTraces) {
@@ -134,12 +135,14 @@ Promise.longStackTraces = function () {
             }
             Promise.prototype._captureStackTrace = Promise_captureStackTrace;
             Promise.prototype._attachExtraTrace = Promise_attachExtraTrace;
+            Promise.prototype._dereferenceTrace = Promise_dereferenceTrace;
             Context.deactivateLongStackTraces();
             async.enableTrampoline();
             config.longStackTraces = false;
         };
         Promise.prototype._captureStackTrace = longStackTracesCaptureStackTrace;
         Promise.prototype._attachExtraTrace = longStackTracesAttachExtraTrace;
+        Promise.prototype._dereferenceTrace = longStackTracesDereferenceTrace;
         Context.activateLongStackTraces();
         async.disableTrampolineIfNecessary();
     }
@@ -325,6 +328,7 @@ Promise.prototype._attachCancellationCallback = function(onCancel) {
 };
 Promise.prototype._captureStackTrace = function () {};
 Promise.prototype._attachExtraTrace = function () {};
+Promise.prototype._dereferenceTrace = function () {};
 Promise.prototype._clearCancellationData = function() {};
 Promise.prototype._propagateFrom = function (parent, flags) {
     USE(parent);
@@ -433,6 +437,10 @@ function longStackTracesAttachExtraTrace(error, ignoreSelf) {
             util.notEnumerableProp(error, "__stackCleaned__", true);
         }
     }
+}
+
+function longStackTracesDereferenceTrace() {
+    this._trace = undefined;
 }
 
 function checkForgottenReturns(returnValue, promiseCreated, name, promise,

--- a/src/promise.js
+++ b/src/promise.js
@@ -681,6 +681,7 @@ Promise.prototype._fulfill = function (value) {
         } else {
             async.settlePromises(this);
         }
+        this._dereferenceTrace();
     }
 };
 

--- a/test/mocha/async.js
+++ b/test/mocha/async.js
@@ -155,13 +155,6 @@ describe("Async requirement", function() {
 
     if (testUtils.isRecentNode) {
         describe("Frees memory of old values in promise chains", function () {
-            if (typeof global.gc !== "function") {
-                var v8 = require("v8");
-                var vm = require("vm");
-                v8.setFlagsFromString("--expose_gc");
-                global.gc = vm.runInNewContext("gc");
-            }
-
             function getHeapUsed() {
                 global.gc();
                 return process.memoryUsage().heapUsed;
@@ -169,7 +162,10 @@ describe("Async requirement", function() {
 
             var initialHeapUsed;
 
-            beforeEach(function () {
+            before(function () {
+                if (typeof global.gc !== "function") {
+                    throw new Error("These tests require the --expose-gc flag");
+                }
                 initialHeapUsed = getHeapUsed();
             });
 


### PR DESCRIPTION
Achieved by draining each queue element in a separate function.

Resolves https://github.com/petkaantonov/bluebird/issues/1529. The issue provides a way to easily reproduce this issue.

I'm currently looking into adding a test to assert this behaviour.