### PR TITLE
Fix embedded code snippet

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -16,7 +16,9 @@ Then:
 ```js
 var Promise = require("bluebird");
 ```
+
 Alternatively in ES6 
+
 ```js
 import * as Promise from 'bluebird';
 ```


### PR DESCRIPTION
There need to be line breaks before the embedded code snippet for "Alternatively in ES6". 

If there are no line breaks, then the programming language (`js`) used for the syntax highlighting will be rendered as part of the sentence in the docs:

**Bug**

![image](https://user-images.githubusercontent.com/469989/47718088-c6bf1380-dc47-11e8-8111-501368939656.png)

You can see the problem here: http://bluebirdjs.com/docs/getting-started.html
