### PR TITLE
make thenable callbacks run asynchronously

### DIFF
--- a/src/thenables.js
+++ b/src/thenables.js
@@ -27,7 +27,7 @@ function tryConvertToPromise(obj, context) {
                 );
                 return ret;
             }
-            return doThenable(obj, then, context);
+            return doThenableAsync(obj, then, context);
         }
     }
     return obj;
@@ -53,6 +53,25 @@ function isAnyBluebirdPromise(obj) {
     } catch (e) {
         return false;
     }
+}
+
+function doThenableAsync(x, then, context) {
+    ASSERT(typeof then === "function");
+    var root = Promise.resolve(undefined);
+    var promise = root.then(resolve, reject);
+    var ret = promise;
+
+    function resolve() {
+        if (!promise) return;
+        promise = null;
+        return doThenable(x, then, context);
+    }
+    function reject(reason) {
+        if (!promise) return;
+        promise = null;
+        promise._rejectCallback(reason, false, true);
+    }
+    return ret;
 }
 
 function doThenable(x, then, context) {

--- a/test/mocha/cancel.js
+++ b/test/mocha/cancel.js
@@ -685,28 +685,30 @@ describe("Cancellation", function() {
     });
 
     specify("if onCancel callback causes synchronous rejection, it is ignored and cancellation wins", function() {
+        var cancel;
         var promisifiedXhr = function() {
             var xhrReject;
             var xhr = {
-                then: function(resolve, reject) {
-                    xhrReject = reject;
+                then: function(_, __) {
+                    cancel();
                 },
                 abort: function() {
                     xhrReject(new Error(""));
                 }
             };
-            return new Promise(function(resolve, _, onCancel) {
-                resolve(xhr);
+            return new Promise(function(resolve, reject, onCancel) {
+                xhrReject = reject;
                 onCancel(function() {
                     xhr.abort();
                 });
+                Promise.resolve(xhr);
             });
         };
 
         var req = promisifiedXhr().lastly(function() {
             resolve();
         });
-        req.cancel();
+        cancel = function() {req.cancel()};
         var resolve;
         return new Promise(function(_, __, onCancel) {resolve = arguments[0]});
     });


### PR DESCRIPTION
Closes https://github.com/petkaantonov/bluebird/issues/1558

Thenable callbacks used to be run synchronously. Now they are run synchronously.
Fixed one broken test. The test depended on the thenable callback being called synchronously.