### PR TITLE
Remove disqus and its ads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ js/*
 zalgo.js
 coverage/*
 .vscode
+.idea

--- a/docs/docs/api/aggregateerror.md
+++ b/docs/docs/api/aggregateerror.md
@@ -33,17 +33,3 @@ throw err;
 
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "AggregateError";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-aggregateerror";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/all.md
+++ b/docs/docs/api/all.md
@@ -18,16 +18,3 @@ Consume the resolved [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/J
 [Promise.resolve(iterable).all()](.) is the same as [Promise.all(iterable)](.).
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".all";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-all";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/any.md
+++ b/docs/docs/api/any.md
@@ -15,17 +15,3 @@ title: .any
 
 Same as [Promise.any(this)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".any";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-any";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/ascallback.md
+++ b/docs/docs/api/ascallback.md
@@ -98,17 +98,3 @@ Promise.resolve(123).asCallback(function(err, a, b, c) {
 
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".asCallback";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-ascallback";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/bind.md
+++ b/docs/docs/api/bind.md
@@ -15,17 +15,3 @@ title: .bind
 
 Same as calling [Promise.bind(thisArg, thisPromise)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".bind";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-bind";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/built-in-error-types.md
+++ b/docs/docs/api/built-in-error-types.md
@@ -15,17 +15,3 @@ becoming the `.message` property of the error object.
 
 By default the error types need to be referenced from the Promise constructor, e.g. to get a reference to [TimeoutError](.), do `var TimeoutError = Promise.TimeoutError`. However, for convenience you will probably want to just make the references global.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Built-in error types";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-built-in-error-types";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/call.md
+++ b/docs/docs/api/call.md
@@ -85,17 +85,3 @@ fs.readdirAsync(".").then(_)
     .then(console.log)
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".call";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-call";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/cancel.md
+++ b/docs/docs/api/cancel.md
@@ -17,17 +17,3 @@ Cancel this promise. Will not do anything if this promise is already settled or 
 
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".cancel";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-cancel";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/cancellation.md
+++ b/docs/docs/api/cancellation.md
@@ -99,16 +99,3 @@ Note that it is an error to consume an already cancelled promise, doing such a t
 <hr>
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Cancellation";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-cancellation";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/cancellationerror.md
+++ b/docs/docs/api/cancellationerror.md
@@ -16,17 +16,3 @@ new CancellationError(String message) -> CancellationError
 
 Signals that an operation has been aborted or cancelled. The default reason used by [`.cancel`](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "CancellationError";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-cancellationerror";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/catch.md
+++ b/docs/docs/api/catch.md
@@ -212,16 +212,3 @@ try {
 console.log(result);
 ```
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".catch";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-catch";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/catchreturn.md
+++ b/docs/docs/api/catchreturn.md
@@ -27,17 +27,3 @@ You may optionally prepend one predicate function or ErrorClass to pattern match
 
 Same limitations regarding to the binding time of `value` to apply as with [`.return`](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".catchReturn";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-catchreturn";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/catchthrow.md
+++ b/docs/docs/api/catchthrow.md
@@ -27,17 +27,3 @@ You may optionally prepend one predicate function or ErrorClass to pattern match
 
 Same limitations regarding to the binding time of `reason` to apply as with [`.return`](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".catchThrow";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-catchthrow";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/collections.md
+++ b/docs/docs/api/collections.md
@@ -16,17 +16,3 @@ All collection methods have a static equivalent on the Promise object, e.g. `som
 
 None of the collection methods modify the original input. Holes in arrays are treated as if they were defined with the value `undefined`.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Collections";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-collections";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/core.md
+++ b/docs/docs/api/core.md
@@ -11,17 +11,3 @@ title: Core
 
 Core methods of `Promise` instances and core static methods of the Promise class.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Core";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-core";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/deferred-migration.md
+++ b/docs/docs/api/deferred-migration.md
@@ -29,16 +29,3 @@ function defer() {
 For old code that still uses deferred objects, see [the deprecated API docs ](//bluebirdjs.com/docs/deprecated-apis.html#promise-resolution).
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Deferred migration";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-deferred-migration";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/delay.md
+++ b/docs/docs/api/delay.md
@@ -15,17 +15,3 @@ title: .delay
 
 Same as calling [Promise.delay(ms, this)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".delay";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-delay";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/disposer.md
+++ b/docs/docs/api/disposer.md
@@ -143,16 +143,3 @@ withTransaction(function(tx) {
 <hr>
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".disposer";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-disposer";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/done.md
+++ b/docs/docs/api/done.md
@@ -21,17 +21,3 @@ Like [`.then`](.), but any unhandled rejection that ends up here will crash the 
 
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".done";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-done";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/each.md
+++ b/docs/docs/api/each.md
@@ -35,17 +35,3 @@ function loadStory() {
 ```
 
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".each";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-each";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/environment-variables.md
+++ b/docs/docs/api/environment-variables.md
@@ -25,17 +25,3 @@ Environment variables supported by 3.x:
 - `BLUEBIRD_WARNINGS` - if set exactly to `0` it will explicitly disable warnings and this overrides any other setting that might enable warnings. If set to any truthy value, it will explicitly enable warnings.
 - `BLUEBIRD_LONG_STACK_TRACES` - if set exactly to `0` it will explicitly disable long stack traces and this overrides any other setting that might enable long stack traces. If set to any truthy value, it will explicitly enable long stack traces.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Environment variables";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-environment-variables";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/error-management-configuration.md
+++ b/docs/docs/api/error-management-configuration.md
@@ -91,17 +91,3 @@ window.onrejectionhandled = function(promise) {
 ```
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Error management configuration";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-error-management-configuration";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/error.md
+++ b/docs/docs/api/error.md
@@ -85,17 +85,3 @@ And if the `fs` module causes an error like file not found:
 unable to read file, because:  ENOENT, open 'not_there.txt'
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".error";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-error";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/filter.md
+++ b/docs/docs/api/filter.md
@@ -18,17 +18,3 @@ title: .filter
 
 Same as [Promise.filter(this, filterer, options)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".filter";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-filter";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/finally.md
+++ b/docs/docs/api/finally.md
@@ -81,17 +81,3 @@ If the fade out completes successfully, the returned promise will be fulfilled o
 
 *For compatibility with earlier ECMAScript version, an alias `.lastly` is provided for [`.finally`](.).*
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".finally";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-finally";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/generators.md
+++ b/docs/docs/api/generators.md
@@ -11,17 +11,3 @@ title: Generators
 
 Using ECMAScript6 generators feature to implement C# 5.0 `async/await` like syntax.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Generators";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-generators";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/get.md
+++ b/docs/docs/api/get.md
@@ -43,17 +43,3 @@ Promise.resolve([1,2,3]).get(-1).then(function(value) {
 
 If the `index` is still negative after `obj.length + index`, it will be clamped to 0.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".get";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-get";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/iscancelled.md
+++ b/docs/docs/api/iscancelled.md
@@ -15,17 +15,3 @@ title: .isCancelled
 
 See if this `promise` has been cancelled.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".isCancelled";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-iscancelled";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/isfulfilled.md
+++ b/docs/docs/api/isfulfilled.md
@@ -15,17 +15,3 @@ title: .isFulfilled
 
 See if this promise has been fulfilled.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".isFulfilled";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-isfulfilled";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/ispending.md
+++ b/docs/docs/api/ispending.md
@@ -16,17 +16,3 @@ title: .isPending
 
 See if this `promise` is pending (not fulfilled or rejected or cancelled).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".isPending";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-ispending";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/isrejected.md
+++ b/docs/docs/api/isrejected.md
@@ -15,17 +15,3 @@ title: .isRejected
 
 See if this promise has been rejected.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".isRejected";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-isrejected";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/map.md
+++ b/docs/docs/api/map.md
@@ -18,17 +18,3 @@ title: .map
 
 Same as [Promise.map(this, mapper, options)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".map";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-map";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/mapseries.md
+++ b/docs/docs/api/mapseries.md
@@ -15,17 +15,3 @@ title: .mapseries
 
 Same as [Promise.mapSeries(this, iterator)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".mapSeries";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-mapSeries";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/new-promise.md
+++ b/docs/docs/api/new-promise.md
@@ -64,16 +64,3 @@ function getPromiseResolveFn() {
 ```
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "new Promise";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-new-promise";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/operationalerror.md
+++ b/docs/docs/api/operationalerror.md
@@ -20,16 +20,3 @@ and is not a typed error, it will be converted to a `OperationalError` which has
 `OperationalError`s are caught in [`.error`](.) handlers.
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "OperationalError";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-operationalerror";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/progression-migration.md
+++ b/docs/docs/api/progression-migration.md
@@ -90,16 +90,3 @@ var progressConsumingCoroutine = Promise.coroutine(function* () {
 ```
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Progression migration";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-progression-migration";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.all.md
+++ b/docs/docs/api/promise.all.md
@@ -32,16 +32,3 @@ Promise.all(files).then(function() {
 This method is compatible with [`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) from native promises.
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.all";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.all";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.any.md
+++ b/docs/docs/api/promise.any.md
@@ -15,17 +15,3 @@ Promise.any(Iterable<any>|Promise<Iterable<any>> input) -> Promise
 
 Like [Promise.some](.), with 1 as `count`. However, if the promise fulfills, the fulfillment value is not an array of 1 but the value directly.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.any";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.any";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.bind.md
+++ b/docs/docs/api/promise.bind.md
@@ -162,16 +162,3 @@ Promise.resolve("my-element")
 The above does a `console.log` of `my-element`.  Doing it this way is necessary because neither of the methods (`getElementById`, `console.log`) can be called as stand-alone methods.
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.bind";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.bind";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.config.md
+++ b/docs/docs/api/promise.config.md
@@ -68,17 +68,3 @@ NODE_ENV=development BLUEBIRD_WARNINGS=0 node app.js
 Cancellation is always configured separately per bluebird instance.
 
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.config";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.config";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.coroutine.addyieldhandler.md
+++ b/docs/docs/api/promise.coroutine.addyieldhandler.md
@@ -119,17 +119,3 @@ var readFiles = Promise.coroutine(function* (fileNames) {
 });
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.coroutine.addYieldHandler";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.coroutine.addyieldhandler";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.coroutine.md
+++ b/docs/docs/api/promise.coroutine.md
@@ -61,16 +61,3 @@ Doing `Promise.coroutine` is almost like using the C# `async` keyword to mark th
 You are able to yield non-promise values by adding your own yield handler using  [`Promise.coroutine.addYieldHandler`](.) or calling `Promise.coroutine()` with a yield handler function as `options.yieldHandler`.
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.coroutine";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.coroutine";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.delay.md
+++ b/docs/docs/api/promise.delay.md
@@ -32,16 +32,3 @@ Promise.delay(500).then(function() {
 <hr>
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.delay";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.delay";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.each.md
+++ b/docs/docs/api/promise.each.md
@@ -63,17 +63,3 @@ return Promise.each(fileNames, file => {
 
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.each";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.each";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.filter.md
+++ b/docs/docs/api/promise.filter.md
@@ -58,17 +58,3 @@ fs.readdirAsync(process.cwd()).filter(function(fileName) {
 
 See [Map Option: concurrency](#map-option-concurrency)
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.filter";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.filter";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.fromcallback.md
+++ b/docs/docs/api/promise.fromcallback.md
@@ -64,17 +64,3 @@ emailTemplates(templatesDir).then(function(template) {
 });
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.fromCallback";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.fromcallback";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.getnewlibrarycopy.md
+++ b/docs/docs/api/promise.getnewlibrarycopy.md
@@ -48,17 +48,3 @@ Promise.coroutine(function*() {
 });
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.getNewLibraryCopy";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.getnewlibrarycopy";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.join.md
+++ b/docs/docs/api/promise.join.md
@@ -72,16 +72,3 @@ join(fContents, fStat, fSqlClient, function(contents, stat, sqlClient) {
 *Note: In 1.x and 0.x `Promise.join` used to be a `Promise.all` that took the values in as arguments instead of an array. This behavior has been deprecated but is still supported partially - when the last argument is an immediate function value the new semantics will apply*
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.join";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.join";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.longstacktraces.md
+++ b/docs/docs/api/promise.longstacktraces.md
@@ -78,16 +78,3 @@ While with long stack traces disabled, you would get:
 On client side, long stack traces currently only work in recent Firefoxes, Chrome and Internet Explorer 10+.
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.longStackTraces";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.longstacktraces";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.map.md
+++ b/docs/docs/api/promise.map.md
@@ -122,17 +122,3 @@ reading files: 9ms
 
 The order `map` calls the mapper function on the array elements is not specified, there is no guarantee on the order in which it'll execute the `map`er on the elements. For order guarantee in sequential execution - see [Promise.mapSeries](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.map";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.map";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.mapseries.md
+++ b/docs/docs/api/promise.mapseries.md
@@ -41,17 +41,3 @@ function loadStory() {
 
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.mapSeries";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.mapSeries";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.method.md
+++ b/docs/docs/api/promise.method.md
@@ -56,17 +56,3 @@ MyClass.prototype.method = Promise.method(function(input) {
 });
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.method";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.method";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.noconflict.md
+++ b/docs/docs/api/promise.noconflict.md
@@ -31,17 +31,3 @@ var promise = Bluebird.resolve(new Promise());
 </script>
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.noConflict";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.noconflict";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.onpossiblyunhandledrejection.md
+++ b/docs/docs/api/promise.onpossiblyunhandledrejection.md
@@ -27,16 +27,3 @@ Promise.onPossiblyUnhandledRejection(function(e, promise) {
 Passing no value or a non-function will have the effect of removing any kind of handling for possibly unhandled rejections.
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.onPossiblyUnhandledRejection";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.onpossiblyunhandledrejection";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.onunhandledrejectionhandled.md
+++ b/docs/docs/api/promise.onunhandledrejectionhandled.md
@@ -37,17 +37,3 @@ Promise.onUnhandledRejectionHandled(function(promise) {
 });
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.onUnhandledRejectionHandled";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.onunhandledrejectionhandled";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.promisify.md
+++ b/docs/docs/api/promise.promisify.md
@@ -63,16 +63,3 @@ getAsync.call(redisClient, 'foo').then(function() {
 ```
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.promisify";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.promisify";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.promisifyall.md
+++ b/docs/docs/api/promise.promisifyall.md
@@ -247,16 +247,3 @@ This works because the array acts as a "module" where the indices are the "modul
 
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.promisifyAll";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.promisifyall";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.props.md
+++ b/docs/docs/api/promise.props.md
@@ -93,16 +93,3 @@ Promise.join(getPictures(), getComments(), getTweets(),
 ```
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.props";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.props";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.race.md
+++ b/docs/docs/api/promise.race.md
@@ -17,17 +17,3 @@ Given an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 This method is only implemented because it's in the ES6 standard. If you want to race promises to fulfillment the [`.any`](.) method is more appropriate as it doesn't qualify a rejected promise as the winner. It also has less surprises: `.race` must become infinitely pending if an empty array is passed but passing an empty array to [`.any`](.) is more usefully a `RangeError`
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.race";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.race";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.reduce.md
+++ b/docs/docs/api/promise.reduce.md
@@ -37,17 +37,3 @@ Promise.reduce(["file1.txt", "file2.txt", "file3.txt"], function(total, fileName
 
 `Promise.reduce` will start calling the reducer as soon as possible, this is why you might want to use it over `Promise.all` (which awaits for the entire array before you can call [`Array#reduce`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce) on it).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.reduce";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.reduce";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.reject.md
+++ b/docs/docs/api/promise.reject.md
@@ -16,17 +16,3 @@ Promise.reject(any error) -> Promise
 
 Create a promise that is rejected with the given `error`.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.reject";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.reject";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.resolve.md
+++ b/docs/docs/api/promise.resolve.md
@@ -50,16 +50,3 @@ Promise.resolve($.get("http://www.google.com")).then(function() {
 ```
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.resolve";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.resolve";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.setscheduler.md
+++ b/docs/docs/api/promise.setscheduler.md
@@ -39,16 +39,3 @@ Promise.setScheduler(function(fn) {
 
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.setScheduler";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.setscheduler";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.some.md
+++ b/docs/docs/api/promise.some.md
@@ -47,16 +47,3 @@ Promise.some(...)
 ```
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.some";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.some";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.try.md
+++ b/docs/docs/api/promise.try.md
@@ -34,17 +34,3 @@ Now if someone uses this function, they will catch all errors in their Promise `
 
 *For compatibility with earlier ECMAScript version, an alias `Promise.attempt` is provided for [`Promise.try`](.).*
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.try";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.try";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promise.using.md
+++ b/docs/docs/api/promise.using.md
@@ -100,17 +100,3 @@ using(connectionPromises, function(connections) {
 
 
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promise.using";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promise.using";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promiseinspection.md
+++ b/docs/docs/api/promiseinspection.md
@@ -22,17 +22,3 @@ interface PromiseInspection {
 
 This interface is implemented by `Promise` instances as well as the `PromiseInspection` result given by [.reflect()](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "PromiseInspection";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promiseinspection";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/promisification.md
+++ b/docs/docs/api/promisification.md
@@ -134,17 +134,3 @@ Promise.promisifyAll(Object.getPrototypeOf(throwAwayInstance));
 
 See also [`Promise.promisifyAll`](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Promisification";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-promisification";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/props.md
+++ b/docs/docs/api/props.md
@@ -15,17 +15,3 @@ title: .props
 
 Same as [Promise.props(this)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".props";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-props";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/race.md
+++ b/docs/docs/api/race.md
@@ -15,17 +15,3 @@ title: .race
 
 Same as [Promise.race(this)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".race";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-race";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/reason.md
+++ b/docs/docs/api/reason.md
@@ -20,17 +20,3 @@ You should check if this promise is [.isRejected()](.) in code paths where it's 
 
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".reason";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-reason";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/reduce.md
+++ b/docs/docs/api/reduce.md
@@ -19,16 +19,3 @@ title: .reduce
 Same as [Promise.reduce(this, reducer, initialValue)](.).
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".reduce";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-reduce";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/reflect.md
+++ b/docs/docs/api/reflect.md
@@ -51,16 +51,3 @@ Promise.props(Object.keys(object).reduce(function(newObject, key) {
 ```
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".reflect";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-reflect";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/resource-management.md
+++ b/docs/docs/api/resource-management.md
@@ -52,16 +52,3 @@ Continue by reading about [disposers](disposer.html) and [`Promise.using`](promi
 
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Resource management";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-resource-management";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/return.md
+++ b/docs/docs/api/return.md
@@ -60,16 +60,3 @@ writeFile("test.txt", "this is text").then(function(fullPath) {
 *For compatibility with earlier ECMAScript version, an alias `.thenReturn` is provided for [`.return`](.).*
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".return";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-return";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/some.md
+++ b/docs/docs/api/some.md
@@ -15,17 +15,3 @@ title: .some
 
 Same as [Promise.some(this, count)](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".some";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-some";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/spread.md
+++ b/docs/docs/api/spread.md
@@ -68,17 +68,3 @@ Note that [.spread()](.) implicitly does [.all()](.) but the ES6 destructuring s
 
 If you want to coordinate several discrete concurrent promises, use [`Promise.join`](.)
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".spread";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-spread";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/suppressunhandledrejections.md
+++ b/docs/docs/api/suppressunhandledrejections.md
@@ -66,17 +66,3 @@ fetchTweets()
 
 The advantage of using `.suppressUnhandledRejections()` over `.catch(function(){})` is that it doesn't increment the branch count of the promise. Branch counts matter when using cancellation because a promise will only be cancelled if all of its branches want to cancel it.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".suppressUnhandledRejections";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-suppressunhandledrejections";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/synchronous-inspection.md
+++ b/docs/docs/api/synchronous-inspection.md
@@ -56,17 +56,3 @@ function authenticate() {
 
 In the latter the indentation stays flat no matter how many previous variables you need, whereas with the former each additional previous value would require an additional nesting level.
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Synchronous inspection";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-synchronous-inspection";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/tap.md
+++ b/docs/docs/api/tap.md
@@ -50,16 +50,3 @@ doSomething()
 *Note: in browsers it is necessary to call `.tap` with `console.log.bind(console)` because console methods can not be called as stand-alone functions.*
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".tap";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-tap";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/tapcatch.md
+++ b/docs/docs/api/tapcatch.md
@@ -119,17 +119,3 @@ Promise.
 ```
 
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".tapCatch";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-tapCatch";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/then.md
+++ b/docs/docs/api/then.md
@@ -19,17 +19,3 @@ title: .then
 
 [Promises/A+ `.then`](http://promises-aplus.github.io/promises-spec/). If you are new to promises, see the [Beginner's Guide]({{ "/docs/beginners-guide.html" | prepend: site.baseurl }}).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".then";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-then";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/throw.md
+++ b/docs/docs/api/throw.md
@@ -29,17 +29,3 @@ Same limitations regarding to the binding time of `reason` to apply as with [`.r
 
 *For compatibility with earlier ECMAScript version, an alias `.thenThrow` is provided for [`.throw`](.).*
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".throw";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-throw";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/timeout.md
+++ b/docs/docs/api/timeout.md
@@ -38,17 +38,3 @@ fs.readFileAsync("huge-file.txt").timeout(100).then(function(fileContents) {
 });
 ```
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".timeout";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-timeout";
-
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/timeouterror.md
+++ b/docs/docs/api/timeouterror.md
@@ -16,17 +16,3 @@ new TimeoutError(String message) -> TimeoutError
 
 Signals that an operation has timed out. Used as a custom cancellation reason in [`.timeout`](.).
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "TimeoutError";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-timeouterror";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/timers.md
+++ b/docs/docs/api/timers.md
@@ -13,17 +13,3 @@ Methods to delay and time promises out.
 
 <div class="api-code-section"><markdown>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Timers";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-timers";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/utility.md
+++ b/docs/docs/api/utility.md
@@ -13,17 +13,3 @@ Functions that could potentially be handy in some situations.
 
 <hr>
 </markdown></div>
-
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = "Utility";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-utility";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/docs/docs/api/value.md
+++ b/docs/docs/api/value.md
@@ -19,16 +19,3 @@ Get the fulfillment value of this promise. Throws an error if the promise isn't 
 You should check if this promise is [.isFulfilled()](.) in code paths where it's not guaranteed that this promise is fulfilled.
 </markdown></div>
 
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_title = ".value";
-    var disqus_shortname = "bluebirdjs";
-    var disqus_identifier = "disqus-id-value";
-    
-    (function() {
-        var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-        dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>


### PR DESCRIPTION
As reported in #1515 #1322 and #1085 

Disqus have [removed the ability to disable ads](https://help.disqus.com/ads/updating-your-advertising-settings) and have started showing video ads which grind some docs pages to a halt.

This PR removes all the disqus from the docs and its ads with it
