### PR TITLE
Update jsdelivr url in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ js/*
 zalgo.js
 coverage/*
 .vscode
+.idea

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -134,7 +134,7 @@
     <footer></footer>
     <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
-    <script src="//cdn.jsdelivr.net/bluebird/{{ site.version }}/bluebird.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bluebird@{{ site.version }}/js/browser/bluebird.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Currently this is 404ing on the live docs

Updated to be the same as suggested on the [install](http://bluebirdjs.com/docs/install.html) page