### PR TITLE
Fix issue #1579

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -128,7 +128,7 @@ MappingPromiseArray.prototype._drainQueue = function () {
     var values = this._values;
     while (queue.length > 0 && this._inFlight < limit) {
         if (this._isResolved()) return;
-        var index = queue.pop();
+        var index = queue.shift();
         this._promiseFulfilled(values[index], index);
     }
 };


### PR DESCRIPTION
- This code works well only because there is no real (async) job
```js
Promise.map(
  ["first", "second", "third", "fourth", "fifth"],
  (item, index, length) => console.log(item, index, length),
  { concurrency: 1 }
);
/*
  first 0 5
  second 1 5
  third 2 5
  fourth 3 5
  fifth 4 5
*/
```
- However, if you add some async tasks, .map will interact items using the wrong direction
```js
Promise.map(
  ["first", "second", "third", "fourth", "fifth"],
  (item, index, length) => {
    console.log(item, index, length);
    return new Promise(resolve => setTimeout(resolve, 100));
  },
  { concurrency: 1 }
);
/*
  first 0 5
  fifth 4 5
  fourth 3 5
  third 2 5
  second 1 5
*/
```

Related issue https://github.com/petkaantonov/bluebird/issues/1579