### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -36,7 +36,7 @@ $ bower install --save bluebird
 ###Browserify and Webpack
 
 ```
-$ npm install --save bluebird
+$ npm install bluebird
 ```
 
 ```js
@@ -51,7 +51,7 @@ Promise.config({
 ##Node installation
 
 ```
-$ npm install --save bluebird
+$ npm install bluebird
 ```
 
 ```js


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358