### PR TITLE
.md syntax fix for coming-from-other-languages.md

### DIFF
--- a/docs/docs/coming-from-other-languages.md
+++ b/docs/docs/coming-from-other-languages.md
@@ -31,7 +31,7 @@ In addition promises are always unwrapped. A promise implicitly has `Task.Unwrap
 
 See [this question on StackOverflow](http://stackoverflow.com/questions/26136389/how-can-i-realize-pattern-promise-deffered) for more differences.
 
-##Scala
+## Scala
 
 A bluebird promise is similar to a Scala `Future`. A scala `Promise` is similar to how the promise constructor can be used (previously, to a bluebird Deferred).
 
@@ -43,7 +43,7 @@ In addition promises are always unwrapped. That is, promises perform recursive a
 
 See [this question on StackOverflow](http://stackoverflow.com/questions/22724883/js-deferred-promise-future-compared-to-functional-languages-like-scala) for more differences.
 
-##Python
+## Python
 
 A promise is similar to a Twisted Deferred object. In fact the first JavaScript implementations of promises were based on it. However, the APIs have diverged since. The mental model is still very similar.
 
@@ -51,7 +51,7 @@ A promise is _not_ similar to a Python `concurrent.Future` which does not chain 
 
 Asyncio coroutines are similar to bluebird coroutines in what they let you do, however bluebird coroutines also enable functional-style chaining.
 
-##C++
+## C++
 
 A bluebird promise is similar to a `std::future` and the promise constructor is similar to an `std::promise` although it should rarely be used in practice (see the promisification section).
 
@@ -59,7 +59,7 @@ However, a bluebird promise is more powerful than the current implementation of 
 
 Boost futures expose a `.then` method similar to promises and allow this functionality.
 
-##Haskell
+## Haskell
 
 A promise is a monadic construct with `.then` filling the role of `>>=` (bind). The major difference is that `.then` performs recursive assimilation which acts like a `flatMap` or a map. The type signature of `then` is quote complicated. If we omit the error argument and not throw - it's similar to:
 
@@ -71,16 +71,16 @@ That is, you can return either a promise _or a plain value_ from a `then` withou
 
 Promises perform a role similar to `IO` in that they allow for easy chaining of asynchronous non-blocking operations. `Promise.coroutine` can be seen as similar to `do` notation although in practice it's not an accurate comparison.
 
-##Java
+## Java
 
 A promise is similar to a guava `Future` with `chain` being similar to `then`.
 
 If your'e familiar with Java 8 lambdas, you can think of a promise as a `Future` you can `map` to another future.
 
-##Android Java
+## Android Java
 
 Several popular Android libraries use promises - for example the Parse Java API returns `Task`s which are similar to JavaScript promises.
 
-##Objective-C
+## Objective-C
 
 If you're familiar with PromiseKit, it is based on a same specification bluebird is based on so the API should feel familiar right away.


### PR DESCRIPTION
Titles were lacking spaces, breaking linking from the ToC and making it hard to read.