### PR TITLE
Fix ES6 import strategy

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -20,6 +20,12 @@ var Promise = require("bluebird");
 Alternatively in ES6 
 
 ```js
+import * as Promise from "bluebird";
+```
+
+If that ES6 import [doesn't work](https://github.com/petkaantonov/bluebird/pull/1594)
+
+```js
 import {Promise} from "bluebird";
 ```
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -20,7 +20,7 @@ var Promise = require("bluebird");
 Alternatively in ES6 
 
 ```js
-import * as Promise from 'bluebird';
+import {Promise} from "bluebird";
 ```
 
 ## Browsers


### PR DESCRIPTION
Using the old import strategy, the following error is produced:

```js
Uncaught TypeError: Promise is not a constructor
```

It's been fixed in this PR.