### PR TITLE
unwrap ternary for strict mode compatibility

### DIFF
--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -105,18 +105,24 @@ Promise.prototype._warn = function(message, shouldUseOwnTrace, promise) {
 
 Promise.onPossiblyUnhandledRejection = function (fn) {
     var domain = getDomain();
-    possiblyUnhandledRejection =
-        typeof fn === "function" ? (domain === null ?
-                                            fn : util.domainBind(domain, fn))
-                                 : undefined;
+    if (typeof fn === "function") {
+      possiblyUnhandledRejection = domain === null
+                                   ? fn 
+                                   : util.domainBind(domain, fn);
+    } else {
+      possiblyUnhandledRejection = undefined;
+    }
 };
 
 Promise.onUnhandledRejectionHandled = function (fn) {
     var domain = getDomain();
-    unhandledRejectionHandled =
-        typeof fn === "function" ? (domain === null ?
-                                            fn : util.domainBind(domain, fn))
-                                 : undefined;
+    if (typeof fn === "function") {
+      unhandledRejectionHandled = domain === null
+                                  ? fn 
+                                  : util.domainBind(domain, fn);
+    } else {
+      unhandledRejectionHandled = undefined;
+    }
 };
 
 var disableLongStackTraces = function() {};


### PR DESCRIPTION
When using bluebird as a dependency and building with rollup, `rollup-plugin-commonjs` requires the dependency to work in strict mode.

This PR unrolls a nested ternary which is documented in many places as a code smell and isn't supported in strict mode.