### PR TITLE
Add fallback for unhandled rejection timer on Firefox.

### DIFF
--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -53,12 +53,24 @@ var deferUnhandledRejectionCheck;
             function checkIframe() {
                 if (document.body) {
                     var iframe = document.createElement("iframe");
+                    var iframeClearTimeout;
                     document.body.appendChild(iframe);
                     if (iframe.contentWindow &&
-                        iframe.contentWindow.setTimeout) {
+                        iframe.contentWindow.setTimeout &&
+                        iframe.contentWindow.clearTimeout) {
                         iframeSetTimeout = iframe.contentWindow.setTimeout;
+                        iframeClearTimeout = iframe.contentWindow.clearTimeout;
                     }
                     document.body.removeChild(iframe);
+
+                    // Verify that we're allowed to use a dead iframe's
+                    // setTimeout(). Firefox throws NS_ERROR_NOT_INITIALIZED,
+                    // see #1623.
+                    try {
+                        iframeClearTimeout(iframeSetTimeout(function () {}, 1));
+                    } catch (ex) {
+                        iframeSetTimeout = setTimeout;
+                    }
                 }
             }
             checkIframe();


### PR DESCRIPTION
The default unhandled rejection timer is a setTimeout() from a removed
iframe. On Firefox, this throws NS_ERROR_NOT_INITIALIZED. This code
adds a test to verify that the setTimeout gleaned from the iframe is
functional and falls back to the global function if it isn’t.

This fixes support for rejecting promises on Firefox.

Fixes #1623.