### PR TITLE
Map concurrency retain array order

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -135,7 +135,7 @@ MappingPromiseArray.prototype._drainQueue = function () {
     var values = this._values;
     while (queue.length > 0 && this._inFlight < limit) {
         if (this._isResolved()) return;
-        var index = queue.pop();
+        var index = queue.shift();
         this._promiseFulfilled(values[index], index);
     }
 };

--- a/test/mocha/map.js
+++ b/test/mocha/map.js
@@ -168,49 +168,49 @@ describe("Promise.map-test with concurrency", function () {
     }
 
     specify("should map input values array with concurrency", function() {
-        var input = [1, 2, 3];
+        var input = [1, 2, 3, 4];
         return Promise.map(input, mapper, concurrency).then(
             function(results) {
-                assert.deepEqual(results, [2,4,6]);
+                assert.deepEqual(results, [2,4,6,8]);
             },
             assert.fail
         );
     });
 
     specify("should map input promises array with concurrency", function() {
-        var input = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+        var input = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3), Promise.resolve(4)];
         return Promise.map(input, mapper, concurrency).then(
             function(results) {
-                assert.deepEqual(results, [2,4,6]);
+                assert.deepEqual(results, [2,4,6,8]);
             },
             assert.fail
         );
     });
 
     specify("should map mixed input array with concurrency", function() {
-        var input = [1, Promise.resolve(2), 3];
+        var input = [1, Promise.resolve(2), 3, 4];
         return Promise.map(input, mapper, concurrency).then(
             function(results) {
-                assert.deepEqual(results, [2,4,6]);
+                assert.deepEqual(results, [2,4,6,8]);
             },
             assert.fail
         );
     });
 
     specify("should map input when mapper returns a promise with concurrency", function() {
-        var input = [1,2,3];
+        var input = [1,2,3,4];
         return Promise.map(input, deferredMapper, concurrency).then(
             function(results) {
-                assert.deepEqual(results, [2,4,6]);
+                assert.deepEqual(results, [2,4,6,8]);
             },
             assert.fail
         );
     });
 
     specify("should accept a promise for an array with concurrency", function() {
-        return Promise.map(Promise.resolve([1, Promise.resolve(2), 3]), mapper, concurrency).then(
+        return Promise.map(Promise.resolve([1, Promise.resolve(2), 3, 4]), mapper, concurrency).then(
             function(result) {
-                assert.deepEqual(result, [2,4,6]);
+                assert.deepEqual(result, [2,4,6,8]);
             },
             assert.fail
         );
@@ -222,17 +222,17 @@ describe("Promise.map-test with concurrency", function () {
     });
 
     specify("should map input promises when mapper returns a promise with concurrency", function() {
-        var input = [Promise.resolve(1),Promise.resolve(2),Promise.resolve(3)];
+        var input = [Promise.resolve(1),Promise.resolve(2),Promise.resolve(3),Promise.resolve(4)];
         return Promise.map(input, mapper, concurrency).then(
             function(results) {
-                assert.deepEqual(results, [2,4,6]);
+                assert.deepEqual(results, [2,4,6,8]);
             },
             assert.fail
         );
     });
 
     specify("should reject when input contains rejection with concurrency", function() {
-        var input = [Promise.resolve(1), Promise.reject(2), Promise.resolve(3)];
+        var input = [Promise.resolve(1), Promise.reject(2), Promise.resolve(3), Promise.resolve(4)];
         return Promise.map(input, mapper, concurrency).then(
             assert.fail,
             function(result) {

--- a/test/mocha/map.js
+++ b/test/mocha/map.js
@@ -285,10 +285,10 @@ describe("Promise.map-test with concurrency", function () {
             assert.deepEqual(b, [0, 1, 2, 3, 4]);
             lates.forEach(resolve);
         }).delay(100).then(function() {
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6 ]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
             lates.forEach(resolve);
         }).thenReturn(ret1).then(function() {
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6, 5]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         });
         return Promise.all([ret1, ret2]);
     });


### PR DESCRIPTION
The core of this PR simply changes the `_drainQueue` method used by the `map` method called when it's run with a concurrency limit, which fetches the next Promise in the array using `Array.shift()` instead of `Array.pop()`.

The point of this is to retain the standard behaviour of `map` and process each entry in the source array in the same order in which it was provided, regardless of whether or not a concurrent processing limit has been set, providing more consistent and predictable behaviour.

---

To ensure the unit tests cover this properly, I added an extra item to all typical test inputs, effectively changing `[1, 2, 3]` to `[1, 2, 3, 4]` and updated the order of the outputs for the final "big" test to match the order of the provided input.