### PR TITLE
map() with concurrency limit is ordered when possible (fixes #1626)

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -22,6 +22,7 @@ function MappingPromiseArray(promises, fn, limit, _filter) {
     this._limit = limit;
     this._inFlight = 0;
     this._queue = [];
+    this._queuePosition = 0;
     async.invoke(this._asyncInit, this, undefined);
     if (util.isArray(promises)) {
         for (var i = 0; i < promises.length; ++i) {
@@ -133,9 +134,11 @@ MappingPromiseArray.prototype._drainQueue = function () {
     var queue = this._queue;
     var limit = this._limit;
     var values = this._values;
-    while (queue.length > 0 && this._inFlight < limit) {
+    while (queue.length > this._queuePosition && this._inFlight < limit) {
         if (this._isResolved()) return;
-        var index = queue.pop();
+        var index = queue[this._queuePosition];
+        delete queue[this._queuePosition];
+        ++this._queuePosition;
         this._promiseFulfilled(values[index], index);
     }
 };

--- a/test/mocha/map.js
+++ b/test/mocha/map.js
@@ -285,10 +285,10 @@ describe("Promise.map-test with concurrency", function () {
             assert.deepEqual(b, [0, 1, 2, 3, 4]);
             lates.forEach(resolve);
         }).delay(100).then(function() {
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6 ]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
             lates.forEach(resolve);
         }).thenReturn(ret1).then(function() {
-            assert.deepEqual(b, [0, 1, 2, 3, 4, 10, 9, 8, 7, 6, 5]);
+            assert.deepEqual(b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         });
         return Promise.all([ret1, ret2]);
     });


### PR DESCRIPTION
See [this comment](https://github.com/petkaantonov/bluebird/issues/1626#issuecomment-596755882).