### PR TITLE
Fix entry for v3.7.1

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -12,15 +12,9 @@ Bugfixes:
 
 ## 3.7.1 (2019-10-15)
 
-Features:
-
- - feature
-
 Bugfixes:
 
- - Fix \([#1614](.)\)
- - Fix \([#1613](.)\)
- - Fix \([#1616](.)\)
+ - Fix crash on unhandled rejection checking in node \([#1614](.), [#1613](.), [#1616](.)\)
 
 ## 3.7.0 (2019-10-01)
 


### PR DESCRIPTION
Currently it looks that way:

![image](https://user-images.githubusercontent.com/270491/91162253-25cb0380-e6cc-11ea-875e-abd2fd51bd07.png)
