### PR TITLE
fix link of 'Cancellation'

### DIFF
--- a/docs/docs/deprecated-apis.md
+++ b/docs/docs/deprecated-apis.md
@@ -99,5 +99,5 @@ delay(500).then(function(ms){
 
 ##Old Promise Cancellation
 
-In 2.x, promise cancellation looked very differently. Promise cancellation received a major overhaul for version 3 in order to create a sound variant of cancellable promises. You can still use 2.x cancellation with bluebird 2.x (which is still supported - but not recommended). See [Cancellation](/cancellation.html) for more details. The 2.x docs are [still accessible under the 2.x branch](https://github.com/petkaantonov/bluebird/blob/2.x/API.md).
+In 2.x, promise cancellation looked very differently. Promise cancellation received a major overhaul for version 3 in order to create a sound variant of cancellable promises. You can still use 2.x cancellation with bluebird 2.x (which is still supported - but not recommended). See [Cancellation](/docs/api/cancellation.html) for more details. The 2.x docs are [still accessible under the 2.x branch](https://github.com/petkaantonov/bluebird/blob/2.x/API.md).
 


### PR DESCRIPTION
http://bluebirdjs.com/docs/api/cancellation.html -- works
http://bluebirdjs.com/cancellation.html -- 404